### PR TITLE
fix: address race conditions

### DIFF
--- a/TournamentAPI.IntegrationTests/GraphQL/Tests/Brackets/BracketMutationTests.cs
+++ b/TournamentAPI.IntegrationTests/GraphQL/Tests/Brackets/BracketMutationTests.cs
@@ -230,10 +230,10 @@ public class BracketMutationTests : BaseIntegrationTest
         Assert.True(error.Extensions.ContainsKey("code"));
         Assert.NotNull(error.Message);
 
-        var expectedError = BracketErrors.BracketAlreadyExists(bracketId);
+        var expectedError = BracketErrors.BracketAlreadyExistsForTournament(tournamentCreateBracketId);
         Assert.Equal(expectedError.Code, error.Extensions["code"]?.ToString());
         Assert.Equal(expectedError.Message, error.Message);
-        Assert.Equal(expectedError.Extensions!["BracketId"]?.ToString(), error.Extensions["BracketId"]?.ToString());
+        Assert.Equal(expectedError.Extensions!["TournamentId"]?.ToString(), error.Extensions["TournamentId"]?.ToString());
 
         var tournamentBrackets = await DbContext.Brackets
             .AsNoTracking()

--- a/TournamentAPI.IntegrationTests/GraphQL/Tests/Brackets/BracketMutationTests.cs
+++ b/TournamentAPI.IntegrationTests/GraphQL/Tests/Brackets/BracketMutationTests.cs
@@ -11,6 +11,77 @@ public class BracketMutationTests : BaseIntegrationTest
     }
 
     [Fact]
+    public async Task GenerateBracket_HandlesDbUpdateException_WhenRaceConditionOccurs()
+    {
+        // Arrange
+        var email = "alice@example.com";
+        var password = "Password123!";
+        var tournamentCreateBracketId = 11;
+        using var client1 = CreateClient();
+        using var client2 = CreateClient();
+
+        var tokenResponse = await client1.ExecuteMutationAsync<LoginResponse>(
+            Shared.MutationExamples.Mutations.Users.LoginUser,
+            new
+            {
+                input = new
+                {
+                    email = email,
+                    password = password
+                }
+            });
+        client1.SetAuthToken(tokenResponse.Data.LoginUser.String);
+        client2.SetAuthToken(tokenResponse.Data.LoginUser.String);
+
+        var variables = new
+        {
+            input = new
+            {
+                tournamentId = tournamentCreateBracketId
+            }
+        };
+
+        // Act
+        var task1 = client1.ExecuteMutationAsync<GenerateBracketResponse>(
+            Shared.MutationExamples.Mutations.Bracket.GenerateBracket,
+            variables);
+        var task2 = client2.ExecuteMutationAsync<GenerateBracketResponse>(
+            Shared.MutationExamples.Mutations.Bracket.GenerateBracket,
+            variables);
+
+        var results = await Task.WhenAll(task1, task2);
+
+        // Assert
+        var successResponse = results.FirstOrDefault(r => !r.HasErrors);
+        var errorResponse = results.FirstOrDefault(r => r.HasErrors);
+
+        Assert.NotNull(successResponse);
+        Assert.NotNull(errorResponse);
+        Assert.NotNull(errorResponse.Data);
+        Assert.NotNull(errorResponse.Data.GenerateBracket);
+        Assert.Null(errorResponse.Data.GenerateBracket.Bracket);
+        Assert.NotNull(errorResponse.Errors);
+
+        var error = errorResponse.Errors.First();
+        Assert.NotNull(error);
+        Assert.NotNull(error.Extensions);
+        Assert.True(error.Extensions.ContainsKey("code"));
+        Assert.NotNull(error.Message);
+
+        var expectedError = BracketErrors.BracketAlreadyExistsForTournament(tournamentCreateBracketId);
+        Assert.Equal(expectedError.Code, error.Extensions["code"].ToString());
+        Assert.Equal(expectedError.Message, error.Message);
+        Assert.Equal(expectedError.Extensions!["TournamentId"]!.ToString(), error.Extensions["TournamentId"]?.ToString());
+
+        var bracketsInDb = await DbContext.Brackets
+            .AsNoTracking()
+            .Where(b => b.TournamentId == tournamentCreateBracketId)
+            .ToListAsync();
+
+        Assert.Single(bracketsInDb);
+    }
+
+    [Fact]
     public async Task GenerateBracket_ReturnsTournamentNotFoundError_WhenTournamentDoesNotExist()
     {
         // Arrange
@@ -405,6 +476,78 @@ public class BracketMutationTests : BaseIntegrationTest
     }
 
     [Fact]
+    public async Task UpdateRound_HandlesDbUpdateException_WhenRaceConditionOccurs()
+    {
+        // Arrange
+        var email = "alice@example.com";
+        var password = "Password123!";
+        var bracketId = 5;
+        using var client1 = CreateClient();
+        using var client2 = CreateClient();
+
+        var tokenResponse = await client1.ExecuteMutationAsync<LoginResponse>(
+            Shared.MutationExamples.Mutations.Users.LoginUser,
+            new
+            {
+                input = new
+                {
+                    email = email,
+                    password = password
+                }
+            });
+        client1.SetAuthToken(tokenResponse.Data.LoginUser.String);
+        client2.SetAuthToken(tokenResponse.Data.LoginUser.String);
+
+        var variables = new
+        {
+            input = new
+            {
+                bracketId = bracketId,
+                roundNumber = 1
+            }
+        };
+
+        // Act
+        var task1 = client1.ExecuteMutationAsync<UpdateRoundResponse>(
+            Shared.MutationExamples.Mutations.Bracket.UpdateRound,
+            variables);
+        var task2 = client2.ExecuteMutationAsync<UpdateRoundResponse>(
+            Shared.MutationExamples.Mutations.Bracket.UpdateRound,
+            variables);
+
+        var results = await Task.WhenAll(task1, task2);
+
+        // Assert
+        var successResponse = results.FirstOrDefault(r => !r.HasErrors);
+        var errorResponse = results.FirstOrDefault(r => r.HasErrors);
+
+        Assert.NotNull(successResponse);
+        Assert.NotNull(errorResponse);
+        Assert.NotNull(errorResponse.Data);
+        Assert.NotNull(errorResponse.Data.UpdateRound);
+        Assert.Null(errorResponse.Data.UpdateRound.Bracket);
+        Assert.NotNull(errorResponse.Errors);
+
+        var error = errorResponse.Errors.First();
+        Assert.NotNull(error);
+        Assert.NotNull(error.Extensions);
+        Assert.True(error.Extensions.ContainsKey("code"));
+        Assert.NotNull(error.Message);
+
+        var expectedError = BracketErrors.NextRoundAlreadyGenerated(bracketId);
+        Assert.Equal(expectedError.Code, error.Extensions["code"]?.ToString());
+        Assert.Equal(expectedError.Message, error.Message);
+        Assert.Equal(expectedError.Extensions!["BracketId"]!.ToString(), error.Extensions["BracketId"]?.ToString());
+
+        var matchesInDb = await DbContext.Matches
+            .AsNoTracking()
+            .Where(m => m.BracketId == bracketId && m.Round == 2)
+            .ToListAsync();
+
+        Assert.Single(matchesInDb);
+    }
+
+    [Fact]
     public async Task UpdateRound_ReturnsBracketNotFoundError_WhenBracketDoesNotExist()
     {
         // Arrange
@@ -513,11 +656,12 @@ public class BracketMutationTests : BaseIntegrationTest
         Assert.Equal(expectedError.Extensions!["TournamentId"]?.ToString(), error.Extensions["TournamentId"]?.ToString());
         Assert.Equal(expectedError.Extensions!["UserId"]?.ToString(), error.Extensions["UserId"]?.ToString());
 
-        var bracketInDb = await DbContext.Brackets
+        var matchesInDb = await DbContext.Matches
             .AsNoTracking()
-            .FirstOrDefaultAsync(b => b.Id == bracketId);
+            .Where(m => m.BracketId == bracketId && m.Round == 2)
+            .ToListAsync();
 
-        Assert.NotNull(bracketInDb);
+        Assert.Empty(matchesInDb);
     }
 
     [Fact]
@@ -573,6 +717,13 @@ public class BracketMutationTests : BaseIntegrationTest
         Assert.Equal(expectedError.Code, error.Extensions["code"]?.ToString());
         Assert.Equal(expectedError.Message, error.Message);
         Assert.Equal(expectedError.Extensions!["RoundNumber"]?.ToString(), error.Extensions["RoundNumber"]?.ToString());
+
+        var matchesInDb = await DbContext.Matches
+            .AsNoTracking()
+            .Where(m => m.BracketId == bracketId && m.Round == roundNumber + 1)
+            .ToListAsync();
+
+        Assert.Empty(matchesInDb);
     }
 
     [Fact]
@@ -628,6 +779,13 @@ public class BracketMutationTests : BaseIntegrationTest
         Assert.Equal(expectedError.Code, error.Extensions["code"]?.ToString());
         Assert.Equal(expectedError.Message, error.Message);
         Assert.Equal(expectedError.Extensions!["RoundNumber"]?.ToString(), error.Extensions["RoundNumber"]?.ToString());
+
+        var matchesInDb = await DbContext.Matches
+            .AsNoTracking()
+            .Where(m => m.BracketId == bracketId && m.Round == roundNumber + 1)
+            .ToListAsync();
+
+        Assert.Empty(matchesInDb);
     }
 
     [Fact]

--- a/TournamentAPI.IntegrationTests/GraphQL/Tests/Tournaments/TournamentQueryTests.cs
+++ b/TournamentAPI.IntegrationTests/GraphQL/Tests/Tournaments/TournamentQueryTests.cs
@@ -19,8 +19,8 @@ public class TournamentQueryTests : BaseIntegrationTest
         // Assert
         Assert.False(response.HasErrors);
         Assert.NotNull(response.Data?.Tournaments?.Edges);
-        Assert.Equal(9, response.Data.Tournaments.TotalCount);
-        Assert.Equal(9, response.Data.Tournaments.Edges.Count);
+        Assert.Equal(11, response.Data.Tournaments.TotalCount);
+        Assert.Equal(10, response.Data.Tournaments.Edges.Count);
 
         var tournamentNames = response.Data.Tournaments.Nodes?.Select(t => t.Name).ToList();
         Assert.Contains("Spring Invitational", tournamentNames);
@@ -92,8 +92,8 @@ public class TournamentQueryTests : BaseIntegrationTest
         // Assert
         Assert.False(response.HasErrors);
         Assert.NotNull(response.Data?.Tournaments?.Edges);
-        Assert.Equal(9, response.Data.Tournaments.TotalCount);
-        Assert.Equal(9, response.Data.Tournaments.Edges.Count);
+        Assert.Equal(11, response.Data.Tournaments.TotalCount);
+        Assert.Equal(10, response.Data.Tournaments.Edges.Count);
 
         var springTournament = response.Data.Tournaments.Nodes?.FirstOrDefault(t => t.Name == "Spring Invitational");
         Assert.NotNull(springTournament);
@@ -118,8 +118,8 @@ public class TournamentQueryTests : BaseIntegrationTest
         // Assert
         Assert.False(response.HasErrors);
         Assert.NotNull(response.Data?.Tournaments?.Edges);
-        Assert.Equal(9, response.Data.Tournaments.TotalCount);
-        Assert.Equal(9, response.Data.Tournaments.Edges.Count);
+        Assert.Equal(11, response.Data.Tournaments.TotalCount);
+        Assert.Equal(10, response.Data.Tournaments.Edges.Count);
 
         var springTournament = response.Data.Tournaments.Nodes?.FirstOrDefault(t => t.Name == "Spring Invitational");
         Assert.NotNull(springTournament);
@@ -148,8 +148,8 @@ public class TournamentQueryTests : BaseIntegrationTest
         // Assert
         Assert.False(response.HasErrors);
         Assert.NotNull(response.Data?.Tournaments?.Edges);
-        Assert.Equal(9, response.Data.Tournaments.TotalCount);
-        Assert.Equal(9, response.Data.Tournaments.Edges.Count);
+        Assert.Equal(11, response.Data.Tournaments.TotalCount);
+        Assert.Equal(10, response.Data.Tournaments.Edges.Count);
 
         foreach (var tournament in response.Data.Tournaments.Nodes!)
         {
@@ -172,8 +172,8 @@ public class TournamentQueryTests : BaseIntegrationTest
         // Assert
         Assert.False(response.HasErrors);
         Assert.NotNull(response.Data?.Tournaments?.Edges);
-        Assert.Equal(9, response.Data.Tournaments.TotalCount);
-        Assert.Equal(9, response.Data.Tournaments.Edges.Count);
+        Assert.Equal(11, response.Data.Tournaments.TotalCount);
+        Assert.Equal(10, response.Data.Tournaments.Edges.Count);
 
         var tournamentNames = response.Data.Tournaments.Nodes?.Select(t => t.Name).ToList();
         var sortedNames = tournamentNames?.OrderByDescending(n => n).ToList();
@@ -193,8 +193,8 @@ public class TournamentQueryTests : BaseIntegrationTest
         Assert.False(response.HasErrors);
         Assert.NotNull(response.Data?.Tournaments?.Edges);
 
-        Assert.Equal(9, response.Data.Tournaments.TotalCount);
-        Assert.Equal(9, response.Data.Tournaments.Edges.Count);
+        Assert.Equal(11, response.Data.Tournaments.TotalCount);
+        Assert.Equal(10, response.Data.Tournaments.Edges.Count);
 
         var tournamentNames = response.Data.Tournaments.Nodes?.Select(t => t.Name).ToList();
 

--- a/TournamentAPI.LoadTests/LoadTestWebAppFactory.cs
+++ b/TournamentAPI.LoadTests/LoadTestWebAppFactory.cs
@@ -38,6 +38,7 @@ public class LoadTestWebAppFactory : WebApplicationFactory<Program>, IAsyncLifet
         var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
         var userManager = scope.ServiceProvider.GetRequiredService<Microsoft.AspNetCore.Identity.UserManager<TournamentAPI.Data.Models.ApplicationUser>>();
 
+        await context.Database.EnsureDeletedAsync();
         await context.Database.EnsureCreatedAsync();
         await DatabaseSeeder.SeedAsync(context, userManager);
     }

--- a/TournamentAPI/Brackets/BracketErrors.cs
+++ b/TournamentAPI/Brackets/BracketErrors.cs
@@ -2,11 +2,11 @@ namespace TournamentAPI.Brackets;
 
 public static class BracketErrors
 {
-    public static IError BracketAlreadyExists(int bracketId) =>
+    public static IError BracketAlreadyExistsForTournament(int tournamentId) =>
         ErrorBuilder.New()
             .SetMessage("Bracket already exists for this tournament.")
             .SetCode(BracketErrorCodes.BracketAlreadyExists)
-            .SetExtension("BracketId", bracketId)
+            .SetExtension("TournamentId", tournamentId)
             .Build();
 
     public static IError NotEnoughParticipants(int participantCount) =>

--- a/TournamentAPI/Data/ApplicationDbContext.cs
+++ b/TournamentAPI/Data/ApplicationDbContext.cs
@@ -89,5 +89,9 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser, IdentityR
             .WithMany(b => b.Matches)
             .HasForeignKey(m => m.BracketId)
             .OnDelete(DeleteBehavior.Restrict);
+
+        builder.Entity<Match>()
+            .HasIndex(m => new { m.BracketId, m.Round, m.Player1Id, m.Player2Id })
+            .IsUnique();
     }
 }

--- a/TournamentAPI/Data/DatabaseSeeder.cs
+++ b/TournamentAPI/Data/DatabaseSeeder.cs
@@ -10,9 +10,6 @@ public static class DatabaseSeeder
         ApplicationDbContext context,
         UserManager<ApplicationUser> userManager)
     {
-        await context.Database.EnsureDeletedAsync();
-        await context.Database.EnsureCreatedAsync();
-
         // Create users
         var user1 = new ApplicationUser { UserName = "alice", Email = "alice@example.com", FirstName = "Alice", LastName = "Smith" };
         var user2 = new ApplicationUser { UserName = "bob", Email = "bob@example.com", FirstName = "Bob", LastName = "Johnson" };
@@ -258,7 +255,46 @@ public static class DatabaseSeeder
             tournament10.Participants.Add(new TournamentParticipant { Tournament = tournament10, Participant = user4 });
             tournament10.Participants.Add(new TournamentParticipant { Tournament = tournament10, Participant = user6 });
 
-            context.Tournaments.AddRange(tournament1, tournament2, tournament3, tournament4, tournament5, tournament6, tournament7, tournament8, tournament9, tournament10);
+            var tournament11 = new Tournament
+            {
+                Name = "Solo Tournament",
+                StartDate = DateTime.UtcNow.AddDays(25),
+                Status = TournamentStatus.Closed,
+                OwnerId = user1.Id,
+                Owner = user1,
+                Participants = new List<TournamentParticipant>()
+            };
+
+            tournament11.Participants.Add(new TournamentParticipant { Tournament = tournament11, Participant = user5 });
+            tournament11.Participants.Add(new TournamentParticipant { Tournament = tournament11, Participant = user7 });
+            tournament11.Participants.Add(new TournamentParticipant { Tournament = tournament11, Participant = user8 });
+
+            var tournament12 = new Tournament
+            {
+                Name = "Doubles Tournament",
+                StartDate = DateTime.UtcNow.AddDays(18),
+                Status = TournamentStatus.Closed,
+                OwnerId = user1.Id,
+                Owner = user1,
+                Participants = new List<TournamentParticipant>(),
+                Bracket = new Bracket
+                {
+                    Matches = new List<Match>()
+                }
+            };
+
+            tournament12.Participants.Add(new TournamentParticipant { Tournament = tournament12, Participant = user1 });
+            tournament12.Participants.Add(new TournamentParticipant { Tournament = tournament12, Participant = user2 });
+            tournament12.Participants.Add(new TournamentParticipant { Tournament = tournament12, Participant = user3 });
+            tournament12.Participants.Add(new TournamentParticipant { Tournament = tournament12, Participant = user4 });
+
+            var match16 = new Match { Round = 1, Player1Id = user1.Id, Player2Id = user2.Id, WinnerId = user2.Id, Bracket = tournament12.Bracket };
+            var match17 = new Match { Round = 1, Player1Id = user3.Id, Player2Id = user4.Id, WinnerId = user4.Id, Bracket = tournament12.Bracket };
+
+            tournament12.Bracket.Matches.Add(match16);
+            tournament12.Bracket.Matches.Add(match17);
+
+            await context.Tournaments.AddRangeAsync(tournament1, tournament2, tournament3, tournament4, tournament5, tournament6, tournament7, tournament8, tournament9, tournament10, tournament11, tournament12);
             await context.SaveChangesAsync();
         }
     }

--- a/TournamentAPI/Data/Models/Match.cs
+++ b/TournamentAPI/Data/Models/Match.cs
@@ -1,3 +1,5 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace TournamentAPI.Data.Models;
 
 public class Match
@@ -14,4 +16,7 @@ public class Match
     public ApplicationUser? Player2 { get; set; }
     public ApplicationUser? Winner { get; set; }
     public Bracket Bracket { get; set; } = null!;
+
+    [Timestamp]
+    public byte[] Version { get; set; } = null!;
 }

--- a/TournamentAPI/Extensions/DbUpdateExceptionExtensions.cs
+++ b/TournamentAPI/Extensions/DbUpdateExceptionExtensions.cs
@@ -1,0 +1,13 @@
+using Microsoft.Data.SqlClient;
+using Microsoft.EntityFrameworkCore;
+
+namespace TournamentAPI.Extensions;
+
+public static class DbUpdateExceptionExtensions
+{
+    public static bool IsUniqueConstraintViolation(this DbUpdateException exception)
+    {
+        return exception.InnerException is SqlException sqlException
+            && (sqlException.Number == 2601 || sqlException.Number == 2627);
+    }
+}

--- a/TournamentAPI/Matches/MatchMutations.cs
+++ b/TournamentAPI/Matches/MatchMutations.cs
@@ -64,8 +64,17 @@ public class MatchMutations
         }
 
         match.WinnerId = winnerId;
-        await context.SaveChangesAsync(token);
 
-        return true;
+        try
+        {
+            await context.SaveChangesAsync(token);
+
+            return true;
+        }
+        catch (DbUpdateException)
+        {
+            resolverContext.ReportError(MatchErrors.MatchAlreadyPlayed(matchId));
+            return null;
+        }
     }
 }

--- a/TournamentAPI/Participants/ParticipantMutations.cs
+++ b/TournamentAPI/Participants/ParticipantMutations.cs
@@ -76,12 +76,12 @@ public class ParticipantMutations
         try
         {
             await context.SaveChangesAsync(token);
+            return context.Tournaments.AsNoTracking().Where(t => t.Id == input.TournamentId);
         }
         catch (DbUpdateException)
         {
-            throw new GraphQLException("Failed to add participant due to a database error.");
+            resolverContext.ReportError(TournamentErrors.UserAlreadyParticipant(input.UserId, input.TournamentId));
+            return null;
         }
-
-        return context.Tournaments.AsNoTracking().Where(t => t.Id == input.TournamentId);
     }
 }

--- a/TournamentAPI/Program.cs
+++ b/TournamentAPI/Program.cs
@@ -150,6 +150,8 @@ if (app.Environment.IsDevelopment())
     var context = services.GetRequiredService<ApplicationDbContext>();
     var userManager = services.GetRequiredService<UserManager<ApplicationUser>>();
 
+    await context.Database.EnsureDeletedAsync();
+    await context.Database.EnsureCreatedAsync();
     await DatabaseSeeder.SeedAsync(context, userManager);
 }
 

--- a/TournamentAPI/Tournaments/TournamentMutations.cs
+++ b/TournamentAPI/Tournaments/TournamentMutations.cs
@@ -60,13 +60,14 @@ public class TournamentMutations
         try
         {
             await context.SaveChangesAsync(token);
+            return true;
         }
         catch (DbUpdateException)
         {
-            throw new GraphQLException("Failed to join tournament due to a database error.");
+            resolverContext.ReportError(
+                TournamentErrors.UserAlreadyParticipant(userId, tournamentId));
+            return null;
         }
-
-        return true;
     }
 
     [UseFirstOrDefault]
@@ -211,7 +212,6 @@ public class TournamentMutations
         }
 
         await context.SaveChangesAsync(token);
-
         return true;
     }
 }

--- a/docs/adr/0002_update_round_concurrency.md
+++ b/docs/adr/0002_update_round_concurrency.md
@@ -1,0 +1,28 @@
+# Title
+Eliminate Racing Conditions When Updating Round.
+
+# Date
+19/01/2026
+
+## Status
+Accepted
+
+## Context
+In our current implementation, we don't have a mechanism to prevent racing conditions when updating the tournament round.
+This can lead to potential inconsistencies in the round data, especially when multiple updates occur simultaneously.
+
+## Considered Options
+1. Pessimistic Concurrency Control with Locking
+   - Pros: Ensures that only one update can occur at a time, preventing racing conditions.
+   - Cons: May introduce performance bottlenecks if not managed properly.
+2. Using Database Transactions
+   - Pros: Leverages existing database capabilities to ensure atomicity of updates.
+   - Cons: Can block other operations and may lead to deadlocks if not handled carefully.
+3. Optimistic Concurrency Control implemented via Versioning in EF Core
+   - Pros: Allows multiple updates to occur simultaneously while ensuring data integrity through version checks.
+   - Cons: Requires additional handling for concurrency exceptions. Accepting some wasted work when conflicts occur.
+
+## Decision
+We have decided to implement Optimistic Concurrency Control using Versioning in EF Core.
+The conflicts won't be frequent, and this approach provides a good balance between performance and data integrity. Also we can accept some wasted work in case of conflicts because updates to rounds are not time-critical operations.
+By adding a version field to the round entity, we can detect and handle concurrency conflicts effectively, prompting retries when necessary.


### PR DESCRIPTION
#### Summary
This PR implements optimistic concurrency control and robust error handling for race conditions in tournament, bracket, match, and participant mutations. It also updates test data and adds documentation for the concurrency approach.

#### Changes
- BracketMutations, MatchMutations, ParticipantMutations, and TournamentMutations: Catch DbUpdateException, detect unique constraint violations, and return specific GraphQL errors for concurrency conflicts.
- Match.cs and ApplicationDbContext.cs: Add [Timestamp] Version property and unique index to support optimistic concurrency.
- BracketErrors.cs and related error handling: Update error codes and messages to use correct entity IDs.
- DatabaseSeeder.cs and TournamentQueryTests.cs: Add new tournaments to seed data and update tests for new counts.
- Add 0002_update_round_concurrency.md ADR documenting the concurrency control decision.
