### PR TITLE
test: implement unit tests

### DIFF
--- a/TournamentAPI.UnitTests/Services/BracketServiceTests.cs
+++ b/TournamentAPI.UnitTests/Services/BracketServiceTests.cs
@@ -1,0 +1,123 @@
+using TournamentAPI.Brackets;
+
+namespace TournamentAPI.UnitTests.Services;
+
+public class BracketServiceTests
+{
+    [Fact]
+    public void CreateBracket_SetsTournamentId()
+    {
+        var bracket = BracketService.CreateBracket(tournamentId: 42, participantIds: [1, 2]);
+
+        Assert.Equal(42, bracket.TournamentId);
+    }
+
+    [Fact]
+    public void CreateBracket_WithEvenParticipantCount_CreatesCorrectNumberOfMatches()
+    {
+        var bracket = BracketService.CreateBracket(tournamentId: 1, participantIds: [1, 2, 3, 4]);
+
+        Assert.Equal(2, bracket.Matches.Count);
+    }
+
+    [Fact]
+    public void CreateBracket_WithOddParticipantCount_CreatesCorrectNumberOfMatches()
+    {
+        var bracket = BracketService.CreateBracket(tournamentId: 1, participantIds: [1, 2, 3]);
+
+        Assert.Equal(2, bracket.Matches.Count);
+    }
+
+    [Fact]
+    public void CreateBracket_WithOddParticipantCount_LastMatchHasNullPlayer2()
+    {
+        var bracket = BracketService.CreateBracket(tournamentId: 1, participantIds: [1, 2, 3]);
+
+        var byeMatch = bracket.Matches.SingleOrDefault(m => m.Player2Id == null);
+        Assert.NotNull(byeMatch);
+    }
+
+    [Fact]
+    public void CreateBracket_AllMatchesAreInRoundOne()
+    {
+        var bracket = BracketService.CreateBracket(tournamentId: 1, participantIds: [1, 2, 3, 4]);
+
+        Assert.All(bracket.Matches, m => Assert.Equal(1, m.Round));
+    }
+
+    [Fact]
+    public void CreateBracket_AllParticipantIdsAppearInMatches()
+    {
+        var participantIds = new List<int> { 1, 2, 3, 4 };
+        var bracket = BracketService.CreateBracket(tournamentId: 1, participantIds: participantIds);
+
+        var usedIds = bracket.Matches
+            .SelectMany(m => new[] { m.Player1Id, m.Player2Id ?? -1 })
+            .Where(id => id != -1)
+            .ToHashSet();
+
+        Assert.Equal(participantIds.ToHashSet(), usedIds);
+    }
+
+    [Fact]
+    public void CreateBracket_SetsMatchBracketReference()
+    {
+        var bracket = BracketService.CreateBracket(tournamentId: 1, participantIds: [1, 2]);
+
+        Assert.All(bracket.Matches, m => Assert.Same(bracket, m.Bracket));
+    }
+
+    [Fact]
+    public void CreateNextRoundMatches_WithEvenWinnerCount_CreatesCorrectNumberOfMatches()
+    {
+        var matches = BracketService.CreateNextRoundMatches(bracketId: 1, roundNumber: 1, winners: [1, 2, 3, 4]);
+
+        Assert.Equal(2, matches.Count);
+    }
+
+    [Fact]
+    public void CreateNextRoundMatches_WithOddWinnerCount_LastMatchHasNullPlayer2()
+    {
+        var matches = BracketService.CreateNextRoundMatches(bracketId: 1, roundNumber: 1, winners: [1, 2, 3]);
+
+        var byeMatch = matches.SingleOrDefault(m => m.Player2Id == null);
+        Assert.NotNull(byeMatch);
+    }
+
+    [Fact]
+    public void CreateNextRoundMatches_SetsCorrectRoundNumber()
+    {
+        var matches = BracketService.CreateNextRoundMatches(bracketId: 1, roundNumber: 2, winners: [1, 2]);
+
+        Assert.All(matches, m => Assert.Equal(3, m.Round));
+    }
+
+    [Fact]
+    public void CreateNextRoundMatches_SetsBracketId()
+    {
+        var matches = BracketService.CreateNextRoundMatches(bracketId: 7, roundNumber: 1, winners: [1, 2]);
+
+        Assert.All(matches, m => Assert.Equal(7, m.BracketId));
+    }
+
+    [Fact]
+    public void CreateNextRoundMatches_NormalizesPlayerOrder_LowerIdIsPlayer1()
+    {
+        // Winners [3, 1] — higher ID first, so after normalization Player1Id should be 1
+        var matches = BracketService.CreateNextRoundMatches(bracketId: 1, roundNumber: 1, winners: [3, 1]);
+
+        var match = matches.Single();
+        Assert.Equal(1, match.Player1Id);
+        Assert.Equal(3, match.Player2Id);
+    }
+
+    [Fact]
+    public void CreateNextRoundMatches_WhenPlayerOrderIsAlreadyNormalized_DoesNotSwap()
+    {
+        var matches = BracketService.CreateNextRoundMatches(bracketId: 1, roundNumber: 1, winners: [1, 3]);
+
+        var match = matches.Single();
+        Assert.Equal(1, match.Player1Id);
+        Assert.Equal(3, match.Player2Id);
+    }
+}

--- a/TournamentAPI.UnitTests/Services/JwtServiceTests.cs
+++ b/TournamentAPI.UnitTests/Services/JwtServiceTests.cs
@@ -1,0 +1,125 @@
+using Microsoft.Extensions.Configuration;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using TournamentAPI.Data.Models;
+using TournamentAPI.Services;
+
+namespace TournamentAPI.UnitTests.Services;
+
+public class JwtServiceTests
+{
+    private readonly JwtService _sut;
+    private readonly IConfiguration _configuration;
+
+    public JwtServiceTests()
+    {
+        _configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Jwt:Issuer"] = "test-issuer",
+                ["Jwt:Audience"] = "test-audience",
+                ["Jwt:Key"] = "test-secret-key-that-is-at-least-32-bytes-long!"
+            })
+            .Build();
+
+        _sut = new JwtService(_configuration);
+    }
+
+    [Fact]
+    public void CreateToken_ReturnsNonEmptyString()
+    {
+        var user = CreateTestUser();
+
+        string token = _sut.CreateToken(user);
+
+        Assert.False(string.IsNullOrEmpty(token));
+    }
+
+    [Fact]
+    public void CreateToken_ReturnsValidJwt()
+    {
+        var user = CreateTestUser();
+
+        string token = _sut.CreateToken(user);
+
+        var handler = new JwtSecurityTokenHandler();
+        Assert.True(handler.CanReadToken(token));
+    }
+
+    [Fact]
+    public void CreateToken_ContainsCorrectIssuerAndAudience()
+    {
+        var user = CreateTestUser();
+
+        string token = _sut.CreateToken(user);
+
+        var handler = new JwtSecurityTokenHandler();
+        var jwt = handler.ReadJwtToken(token);
+        Assert.Equal("test-issuer", jwt.Issuer);
+        Assert.Contains("test-audience", jwt.Audiences);
+    }
+
+    [Fact]
+    public void CreateToken_ContainsUserIdClaim()
+    {
+        var user = CreateTestUser(id: 42);
+
+        string token = _sut.CreateToken(user);
+
+        var handler = new JwtSecurityTokenHandler();
+        var jwt = handler.ReadJwtToken(token);
+        var subClaim = jwt.Claims.FirstOrDefault(c => c.Type == JwtRegisteredClaimNames.Sub);
+        Assert.NotNull(subClaim);
+        Assert.Equal("42", subClaim.Value);
+    }
+
+    [Fact]
+    public void CreateToken_ContainsUserNameClaim()
+    {
+        var user = CreateTestUser(userName: "johndoe");
+
+        string token = _sut.CreateToken(user);
+
+        var handler = new JwtSecurityTokenHandler();
+        var jwt = handler.ReadJwtToken(token);
+        var nameClaim = jwt.Claims.FirstOrDefault(c => c.Type == ClaimTypes.Name);
+        Assert.NotNull(nameClaim);
+        Assert.Equal("johndoe", nameClaim.Value);
+    }
+
+    [Fact]
+    public void CreateToken_ContainsEmailClaim()
+    {
+        var user = CreateTestUser(email: "john@example.com");
+
+        string token = _sut.CreateToken(user);
+
+        var handler = new JwtSecurityTokenHandler();
+        var jwt = handler.ReadJwtToken(token);
+        var emailClaim = jwt.Claims.FirstOrDefault(c => c.Type == ClaimTypes.Email);
+        Assert.NotNull(emailClaim);
+        Assert.Equal("john@example.com", emailClaim.Value);
+    }
+
+    [Fact]
+    public void CreateToken_ContainsNameIdentifierClaim()
+    {
+        var user = CreateTestUser(id: 42);
+
+        string token = _sut.CreateToken(user);
+
+        var handler = new JwtSecurityTokenHandler();
+        var jwt = handler.ReadJwtToken(token);
+        var nameIdClaim = jwt.Claims.FirstOrDefault(c => c.Type == ClaimTypes.NameIdentifier);
+        Assert.NotNull(nameIdClaim);
+        Assert.Equal("42", nameIdClaim.Value);
+    }
+
+    private static ApplicationUser CreateTestUser(int id = 1, string userName = "testuser", string email = "test@example.com")
+        => new()
+        {
+            Id = id,
+            UserName = userName,
+            Email = email
+        };
+}

--- a/TournamentAPI.UnitTests/TournamentAPI.UnitTests.csproj
+++ b/TournamentAPI.UnitTests/TournamentAPI.UnitTests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\TournamentAPI\TournamentAPI.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/TournamentAPI.UnitTests/Validations/BracketMutationValidationsTests.cs
+++ b/TournamentAPI.UnitTests/Validations/BracketMutationValidationsTests.cs
@@ -1,0 +1,189 @@
+using HotChocolate;
+using TournamentAPI.Brackets;
+using TournamentAPI.Data.Models;
+
+namespace TournamentAPI.UnitTests.Validations;
+
+public class BracketMutationValidationsTests
+{
+    [Fact]
+    public void ValidateBracketExists_WhenBracketIsNull_ReturnsError()
+    {
+        IError? error = BracketMutationValidations.ValidateBracketExists(null, 1);
+
+        Assert.NotNull(error);
+        Assert.Equal(BracketErrorCodes.BracketNotFound, error.Code);
+    }
+
+    [Fact]
+    public void ValidateBracketExists_WhenBracketExists_ReturnsNull()
+    {
+        var bracket = new Bracket { Id = 1 };
+
+        IError? error = BracketMutationValidations.ValidateBracketExists(bracket, 1);
+
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void ValidateTournamentIsClosed_WhenTournamentIsOpen_ReturnsError()
+    {
+        var tournament = new Tournament { Id = 1, Status = TournamentStatus.Open };
+
+        IError? error = BracketMutationValidations.ValidateTournamentIsClosed(tournament);
+
+        Assert.NotNull(error);
+        Assert.Equal(BracketErrorCodes.BracketGenerationNotAllowed, error.Code);
+    }
+
+    [Fact]
+    public void ValidateTournamentIsClosed_WhenTournamentIsClosed_ReturnsNull()
+    {
+        var tournament = new Tournament { Id = 1, Status = TournamentStatus.Closed };
+
+        IError? error = BracketMutationValidations.ValidateTournamentIsClosed(tournament);
+
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void ValidateBracketDoesNotExist_WhenBracketExists_ReturnsError()
+    {
+        var tournament = new Tournament { Id = 1, Bracket = new Bracket() };
+
+        IError? error = BracketMutationValidations.ValidateBracketDoesNotExist(tournament);
+
+        Assert.NotNull(error);
+        Assert.Equal(BracketErrorCodes.BracketAlreadyExists, error.Code);
+    }
+
+    [Fact]
+    public void ValidateBracketDoesNotExist_WhenBracketDoesNotExist_ReturnsNull()
+    {
+        var tournament = new Tournament { Id = 1, Bracket = null };
+
+        IError? error = BracketMutationValidations.ValidateBracketDoesNotExist(tournament);
+
+        Assert.Null(error);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void ValidateEnoughParticipants_WhenCountIsLessThanTwo_ReturnsError(int count)
+    {
+        IError? error = BracketMutationValidations.ValidateEnoughParticipants(count, 1);
+
+        Assert.NotNull(error);
+        Assert.Equal(BracketErrorCodes.NotEnoughParticipants, error.Code);
+    }
+
+    [Theory]
+    [InlineData(2)]
+    [InlineData(8)]
+    public void ValidateEnoughParticipants_WhenCountIsAtLeastTwo_ReturnsNull(int count)
+    {
+        IError? error = BracketMutationValidations.ValidateEnoughParticipants(count, 1);
+
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void ValidateNextRoundNotGenerated_WhenNextRoundExists_ReturnsError()
+    {
+        var matches = new List<Match>
+        {
+            new() { Round = 1 },
+            new() { Round = 2 }
+        };
+
+        IError? error = BracketMutationValidations.ValidateNextRoundNotGenerated(matches, 1, 1);
+
+        Assert.NotNull(error);
+        Assert.Equal(BracketErrorCodes.NextRoundAlreadyGenerated, error.Code);
+    }
+
+    [Fact]
+    public void ValidateNextRoundNotGenerated_WhenNextRoundDoesNotExist_ReturnsNull()
+    {
+        var matches = new List<Match>
+        {
+            new() { Round = 1 }
+        };
+
+        IError? error = BracketMutationValidations.ValidateNextRoundNotGenerated(matches, 1, 1);
+
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void ValidateMatchesExistInRound_WhenNoMatchesInRound_ReturnsError()
+    {
+        IError? error = BracketMutationValidations.ValidateMatchesExistInRound([], 1);
+
+        Assert.NotNull(error);
+        Assert.Equal(BracketErrorCodes.NoMatchesInRound, error.Code);
+    }
+
+    [Fact]
+    public void ValidateMatchesExistInRound_WhenMatchesExist_ReturnsNull()
+    {
+        var matches = new List<Match> { new() { Round = 1 } };
+
+        IError? error = BracketMutationValidations.ValidateMatchesExistInRound(matches, 1);
+
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void ValidateAllMatchesCompleted_WhenSomeMatchesHaveNoWinner_ReturnsError()
+    {
+        var matches = new List<Match>
+        {
+            new() { WinnerId = 1 },
+            new() { WinnerId = null }
+        };
+
+        IError? error = BracketMutationValidations.ValidateAllMatchesCompleted(matches, 1);
+
+        Assert.NotNull(error);
+        Assert.Equal(BracketErrorCodes.NotAllMatchesPlayed, error.Code);
+    }
+
+    [Fact]
+    public void ValidateAllMatchesCompleted_WhenAllMatchesHaveWinner_ReturnsNull()
+    {
+        var matches = new List<Match>
+        {
+            new() { WinnerId = 1 },
+            new() { WinnerId = 2 }
+        };
+
+        IError? error = BracketMutationValidations.ValidateAllMatchesCompleted(matches, 1);
+
+        Assert.Null(error);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void ValidateNotFinalRound_WhenFewerThanTwoWinners_ReturnsError(int winnerCount)
+    {
+        var winners = Enumerable.Range(1, winnerCount).ToList();
+
+        IError? error = BracketMutationValidations.ValidateNotFinalRound(winners, 1);
+
+        Assert.NotNull(error);
+        Assert.Equal(BracketErrorCodes.BracketAlreadyHasWinner, error.Code);
+    }
+
+    [Fact]
+    public void ValidateNotFinalRound_WhenMultipleWinners_ReturnsNull()
+    {
+        var winners = new List<int> { 1, 2 };
+
+        IError? error = BracketMutationValidations.ValidateNotFinalRound(winners, 1);
+
+        Assert.Null(error);
+    }
+}

--- a/TournamentAPI.UnitTests/Validations/MatchValidationsTests.cs
+++ b/TournamentAPI.UnitTests/Validations/MatchValidationsTests.cs
@@ -1,0 +1,100 @@
+using HotChocolate;
+using TournamentAPI.Data.Models;
+using TournamentAPI.Matches;
+
+namespace TournamentAPI.UnitTests.Validations;
+
+public class MatchValidationsTests
+{
+    [Fact]
+    public void ValidateMatchExists_WhenMatchIsNull_ReturnsError()
+    {
+        IError? error = MatchValidations.ValidateMatchExists(null, 1);
+
+        Assert.NotNull(error);
+        Assert.Equal(MatchErrorCodes.MatchNotFound, error.Code);
+    }
+
+    [Fact]
+    public void ValidateMatchExists_WhenMatchExists_ReturnsNull()
+    {
+        var match = new Match { Id = 1 };
+
+        IError? error = MatchValidations.ValidateMatchExists(match, 1);
+
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void ValidateTournamentIsClosed_WhenTournamentIsOpen_ReturnsError()
+    {
+        var tournament = new Tournament { Id = 1, Status = TournamentStatus.Open };
+
+        IError? error = MatchValidations.ValidateTournamentIsClosed(tournament);
+
+        Assert.NotNull(error);
+        Assert.Equal(MatchErrorCodes.TournamentNotClosed, error.Code);
+    }
+
+    [Fact]
+    public void ValidateTournamentIsClosed_WhenTournamentIsClosed_ReturnsNull()
+    {
+        var tournament = new Tournament { Id = 1, Status = TournamentStatus.Closed };
+
+        IError? error = MatchValidations.ValidateTournamentIsClosed(tournament);
+
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void ValidateMatchNotPlayed_WhenMatchAlreadyHasWinner_ReturnsError()
+    {
+        var match = new Match { Id = 1, WinnerId = 5 };
+
+        IError? error = MatchValidations.ValidateMatchNotPlayed(match);
+
+        Assert.NotNull(error);
+        Assert.Equal(MatchErrorCodes.MatchAlreadyPlayed, error.Code);
+    }
+
+    [Fact]
+    public void ValidateMatchNotPlayed_WhenMatchHasNoWinner_ReturnsNull()
+    {
+        var match = new Match { Id = 1, WinnerId = null };
+
+        IError? error = MatchValidations.ValidateMatchNotPlayed(match);
+
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void ValidateWinnerIsParticipant_WhenWinnerIsNotAParticipant_ReturnsError()
+    {
+        var match = new Match { Id = 1, Player1Id = 2, Player2Id = 3 };
+
+        IError? error = MatchValidations.ValidateWinnerIsParticipant(match, 99);
+
+        Assert.NotNull(error);
+        Assert.Equal(MatchErrorCodes.InvalidMatchWinner, error.Code);
+    }
+
+    [Fact]
+    public void ValidateWinnerIsParticipant_WhenWinnerIsPlayer1_ReturnsNull()
+    {
+        var match = new Match { Id = 1, Player1Id = 2, Player2Id = 3 };
+
+        IError? error = MatchValidations.ValidateWinnerIsParticipant(match, 2);
+
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void ValidateWinnerIsParticipant_WhenWinnerIsPlayer2_ReturnsNull()
+    {
+        var match = new Match { Id = 1, Player1Id = 2, Player2Id = 3 };
+
+        IError? error = MatchValidations.ValidateWinnerIsParticipant(match, 3);
+
+        Assert.Null(error);
+    }
+}

--- a/TournamentAPI.UnitTests/Validations/TournamentValidationsTests.cs
+++ b/TournamentAPI.UnitTests/Validations/TournamentValidationsTests.cs
@@ -1,0 +1,120 @@
+using HotChocolate;
+using TournamentAPI.Data.Models;
+using TournamentAPI.Tournaments;
+
+namespace TournamentAPI.UnitTests.Validations;
+
+public class TournamentValidationsTests
+{
+    [Fact]
+    public void ValidateTournamentExists_WhenTournamentIsNull_ReturnsError()
+    {
+        IError? error = TournamentValidations.ValidateTournamentExists(null, 1);
+
+        Assert.NotNull(error);
+        Assert.Equal(TournamentErrorCodes.TournamentNotFound, error.Code);
+    }
+
+    [Fact]
+    public void ValidateTournamentExists_WhenTournamentExists_ReturnsNull()
+    {
+        var tournament = new Tournament { Id = 1 };
+
+        IError? error = TournamentValidations.ValidateTournamentExists(tournament, 1);
+
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void ValidateIsOwner_WhenUserIsNotOwner_ReturnsError()
+    {
+        IError? error = TournamentValidations.ValidateIsOwner(ownerId: 1, userId: 2, tournamentId: 10);
+
+        Assert.NotNull(error);
+        Assert.Equal(TournamentErrorCodes.TournamentNotOwner, error.Code);
+    }
+
+    [Fact]
+    public void ValidateIsOwner_WhenUserIsOwner_ReturnsNull()
+    {
+        IError? error = TournamentValidations.ValidateIsOwner(ownerId: 1, userId: 1, tournamentId: 10);
+
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void ValidateTournamentIsNotClosed_WhenTournamentIsClosed_ReturnsError()
+    {
+        var tournament = new Tournament { Id = 1, Status = TournamentStatus.Closed };
+
+        IError? error = TournamentValidations.ValidateTournamentIsNotClosed(tournament);
+
+        Assert.NotNull(error);
+        Assert.Equal(TournamentErrorCodes.TournamentClosed, error.Code);
+    }
+
+    [Fact]
+    public void ValidateTournamentIsNotClosed_WhenTournamentIsOpen_ReturnsNull()
+    {
+        var tournament = new Tournament { Id = 1, Status = TournamentStatus.Open };
+
+        IError? error = TournamentValidations.ValidateTournamentIsNotClosed(tournament);
+
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void ValidateUserNotAlreadyParticipant_WhenUserIsAlreadyParticipant_ReturnsError()
+    {
+        var tournament = new Tournament
+        {
+            Id = 1,
+            Participants =
+            [
+                new() { ParticipantId = 5 }
+            ]
+        };
+
+        IError? error = TournamentValidations.ValidateUserNotAlreadyParticipant(tournament, 5);
+
+        Assert.NotNull(error);
+        Assert.Equal(TournamentErrorCodes.UserAlreadyParticipant, error.Code);
+    }
+
+    [Fact]
+    public void ValidateUserNotAlreadyParticipant_WhenUserIsNotParticipant_ReturnsNull()
+    {
+        var tournament = new Tournament
+        {
+            Id = 1,
+            Participants =
+            [
+                new() { ParticipantId = 5 }
+            ]
+        };
+
+        IError? error = TournamentValidations.ValidateUserNotAlreadyParticipant(tournament, 99);
+
+        Assert.Null(error);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ValidateTournamentNameNotEmpty_WhenNameIsNullOrWhitespace_ReturnsError(string? name)
+    {
+        IError? error = TournamentValidations.ValidateTournamentNameNotEmpty(name);
+
+        Assert.NotNull(error);
+        Assert.Equal(TournamentErrorCodes.TournamentNameEmpty, error.Code);
+    }
+
+    [Fact]
+    public void ValidateTournamentNameNotEmpty_WhenNameIsValid_ReturnsNull()
+    {
+        IError? error = TournamentValidations.ValidateTournamentNameNotEmpty("Spring Open");
+
+        Assert.Null(error);
+    }
+}

--- a/TournamentAPI.UnitTests/Validations/UserValidationsTests.cs
+++ b/TournamentAPI.UnitTests/Validations/UserValidationsTests.cs
@@ -1,0 +1,46 @@
+using HotChocolate;
+using TournamentAPI.Data.Models;
+using TournamentAPI.Users;
+
+namespace TournamentAPI.UnitTests.Validations;
+
+public class UserValidationsTests
+{
+    [Fact]
+    public void ValidateUserExists_WhenUserIsNull_ReturnsError()
+    {
+        IError? error = UserValidations.ValidateUserExists(null, 1);
+
+        Assert.NotNull(error);
+        Assert.Equal(UserErrorCodes.UserNotFound, error.Code);
+    }
+
+    [Fact]
+    public void ValidateUserExists_WhenUserExists_ReturnsNull()
+    {
+        var user = new ApplicationUser { Id = 1 };
+
+        IError? error = UserValidations.ValidateUserExists(user, 1);
+
+        Assert.Null(error);
+    }
+
+    [Fact]
+    public void ValidateCredentials_WhenUserIsNull_ReturnsError()
+    {
+        IError? error = UserValidations.ValidateCredentials(null);
+
+        Assert.NotNull(error);
+        Assert.Equal(UserErrorCodes.InvalidCredentials, error.Code);
+    }
+
+    [Fact]
+    public void ValidateCredentials_WhenUserExists_ReturnsNull()
+    {
+        var user = new ApplicationUser { Id = 1 };
+
+        IError? error = UserValidations.ValidateCredentials(user);
+
+        Assert.Null(error);
+    }
+}

--- a/TournamentAPI.sln
+++ b/TournamentAPI.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.13.36105.23
+# Visual Studio Version 18
+VisualStudioVersion = 18.4.11612.150 stable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TournamentAPI", "TournamentAPI\TournamentAPI.csproj", "{80ADA061-EA86-4886-B91A-ABB20F05375A}"
 EndProject
@@ -12,6 +12,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TournamentAPI.Shared", "TournamentAPI.Shared\TournamentAPI.Shared.csproj", "{BDEBB3B0-18BF-45DA-85D2-CB9D437783CF}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TournamentAPI.LoadTests", "TournamentAPI.LoadTests\TournamentAPI.LoadTests.csproj", "{04030980-4EAF-49A2-AD8E-B9B56EEE6F17}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TournamentAPI.UnitTests", "TournamentAPI.UnitTests\TournamentAPI.UnitTests.csproj", "{214A6968-FF66-42DB-B78D-27C94B1D297E}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -39,6 +41,10 @@ Global
 		{04030980-4EAF-49A2-AD8E-B9B56EEE6F17}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{04030980-4EAF-49A2-AD8E-B9B56EEE6F17}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{04030980-4EAF-49A2-AD8E-B9B56EEE6F17}.Release|Any CPU.Build.0 = Release|Any CPU
+		{214A6968-FF66-42DB-B78D-27C94B1D297E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{214A6968-FF66-42DB-B78D-27C94B1D297E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{214A6968-FF66-42DB-B78D-27C94B1D297E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{214A6968-FF66-42DB-B78D-27C94B1D297E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
#### Summary
Introduces a new TournamentAPI.UnitTests project with extensive unit tests for core validation and service logic.

#### Changes
- BracketServiceTests.cs: Adds tests for bracket creation and round progression logic.
- JwtServiceTests.cs: Adds tests for JWT token generation and claims validation.
- BracketMutationValidationsTests.cs, MatchValidationsTests.cs, TournamentValidationsTests.cs, UserValidationsTests.cs: Add tests for validation logic in brackets, matches, tournaments, and users.
- TournamentAPI.UnitTests.csproj: Adds new test project configuration and dependencies.
- TournamentAPI.sln: Registers the new unit test project in the solution.
