### PR TITLE
feat: implement refresh tokens

### DIFF
--- a/TournamentAPI.IntegrationTests/GraphQL/Tests/Users/UserMutationTests.cs
+++ b/TournamentAPI.IntegrationTests/GraphQL/Tests/Users/UserMutationTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.EntityFrameworkCore;
+using TournamentAPI.Data.Models;
 using TournamentAPI.Shared.Extensions;
 using TournamentAPI.Shared.Models;
 using TournamentAPI.Users;
@@ -206,5 +207,123 @@ public class UserMutationTests : BaseIntegrationTest
         var expectedError = UserErrors.InvalidCredentials();
         Assert.Equal(expectedError.Code, error.Extensions["code"]?.ToString());
         Assert.Equal(expectedError.Message, error.Message);
+    }
+
+    [Fact]
+    public async Task LoginUser_SetsRefreshTokenCookie()
+    {
+        using var client = CreateClient();
+
+        await client.ExecuteMutationAsync<LoginResponse>(
+            Shared.MutationExamples.Mutations.Users.LoginUser,
+            new { input = new { email = "alice@example.com", password = "Password123!" } });
+
+        var cookie = client.GetRefreshTokenCookie();
+        Assert.NotNull(cookie);
+        Assert.NotEmpty(cookie);
+    }
+
+    [Fact]
+    public async Task RefreshToken_ReturnsNewAccessToken_WhenCookieIsValid()
+    {
+        using var client = CreateClient();
+
+        await client.ExecuteMutationAsync<LoginResponse>(
+            Shared.MutationExamples.Mutations.Users.LoginUser,
+            new { input = new { email = "alice@example.com", password = "Password123!" } });
+
+        var refreshToken = client.GetRefreshTokenCookie();
+        Assert.NotNull(refreshToken);
+        client.SetRefreshTokenCookie(refreshToken);
+
+        var response = await client.ExecuteMutationAsync<RefreshTokenResponse>(
+            Shared.MutationExamples.Mutations.Users.RefreshToken,
+            new { });
+
+        Assert.False(response.HasErrors);
+        Assert.NotNull(response.Data?.RefreshToken?.String);
+    }
+
+    [Fact]
+    public async Task RefreshToken_RotatesToken()
+    {
+        using var client = CreateClient();
+
+        await client.ExecuteMutationAsync<LoginResponse>(
+            Shared.MutationExamples.Mutations.Users.LoginUser,
+            new { input = new { email = "alice@example.com", password = "Password123!" } });
+
+        var originalToken = client.GetRefreshTokenCookie();
+        Assert.NotNull(originalToken);
+        client.SetRefreshTokenCookie(originalToken);
+
+        await client.ExecuteMutationAsync<RefreshTokenResponse>(
+            Shared.MutationExamples.Mutations.Users.RefreshToken,
+            new { });
+
+        var rotatedToken = client.GetRefreshTokenCookie();
+        Assert.NotNull(rotatedToken);
+        Assert.NotEqual(originalToken, rotatedToken);
+    }
+
+    [Fact]
+    public async Task RefreshToken_ReturnsInvalidError_WhenCookieIsMissing()
+    {
+        using var client = CreateClient();
+
+        var response = await client.ExecuteMutationAsync<RefreshTokenResponse>(
+            Shared.MutationExamples.Mutations.Users.RefreshToken,
+            new { });
+
+        Assert.True(response.HasErrors);
+        var error = response.Errors!.First();
+        var expectedError = UserErrors.RefreshTokenInvalid();
+        Assert.Equal(expectedError.Code, error.Extensions!["code"]?.ToString());
+        Assert.Equal(expectedError.Message, error.Message);
+    }
+
+    [Fact]
+    public async Task RefreshToken_ReturnsExpiredError_WhenTokenIsExpired()
+    {
+        var alice = await DbContext.Users.FirstAsync(u => u.Email == "alice@example.com");
+        var expiredToken = new RefreshToken
+        {
+            Id = Guid.NewGuid(),
+            UserId = alice.Id,
+            Token = "expired-token-value",
+            ExpiryDateUtc = DateTime.UtcNow.AddDays(-1)
+        };
+        DbContext.RefreshTokens.Add(expiredToken);
+        await DbContext.SaveChangesAsync();
+
+        using var client = CreateClient();
+        client.SetRefreshTokenCookie(expiredToken.Token);
+
+        var response = await client.ExecuteMutationAsync<RefreshTokenResponse>(
+            Shared.MutationExamples.Mutations.Users.RefreshToken,
+            new { });
+
+        Assert.True(response.HasErrors);
+        var error = response.Errors!.First();
+        var expectedError = UserErrors.RefreshTokenExpired();
+        Assert.Equal(expectedError.Code, error.Extensions!["code"]?.ToString());
+        Assert.Equal(expectedError.Message, error.Message);
+    }
+
+    [Fact]
+    public async Task LoginUser_RemovesOldRefreshTokens_OnReLogin()
+    {
+        using var client = CreateClient();
+        var loginVars = new { input = new { email = "alice@example.com", password = "Password123!" } };
+
+        await client.ExecuteMutationAsync<LoginResponse>(
+            Shared.MutationExamples.Mutations.Users.LoginUser, loginVars);
+
+        await client.ExecuteMutationAsync<LoginResponse>(
+            Shared.MutationExamples.Mutations.Users.LoginUser, loginVars);
+
+        var alice = await DbContext.Users.FirstAsync(u => u.Email == "alice@example.com");
+        var tokenCount = await DbContext.RefreshTokens.CountAsync(r => r.UserId == alice.Id);
+        Assert.Equal(1, tokenCount);
     }
 }

--- a/TournamentAPI.Shared/Helpers/TestClient.cs
+++ b/TournamentAPI.Shared/Helpers/TestClient.cs
@@ -7,6 +7,7 @@ namespace TournamentAPI.Shared.Helpers;
 public class TestClient : IDisposable
 {
     private readonly HttpClient _client;
+    private HttpResponseMessage? _lastResponse;
     public HttpClient HttpClient => _client;
 
     public TestClient(HttpClient client)
@@ -25,6 +26,23 @@ public class TestClient : IDisposable
         _client.DefaultRequestHeaders.Authorization = null;
     }
 
+    public string? GetRefreshTokenCookie()
+    {
+        if (_lastResponse is null) return null;
+        if (!_lastResponse.Headers.TryGetValues("Set-Cookie", out var cookies)) return null;
+
+        var refreshCookie = cookies.FirstOrDefault(c => c.StartsWith("refreshToken="));
+        if (refreshCookie is null) return null;
+
+        return refreshCookie.Split(';')[0]["refreshToken=".Length..];
+    }
+
+    public void SetRefreshTokenCookie(string token)
+    {
+        _client.DefaultRequestHeaders.Remove("Cookie");
+        _client.DefaultRequestHeaders.Add("Cookie", $"refreshToken={token}");
+    }
+
     public async Task<GraphQLResponse<T>> ExecuteQueryAsync<T>(
         string query,
         object? variables = null,
@@ -37,6 +55,7 @@ public class TestClient : IDisposable
         };
 
         var response = await _client.PostAsJsonAsync("/graphql", request, cancellationToken);
+        _lastResponse = response;
 
         if (response.StatusCode == HttpStatusCode.TooManyRequests)
         {

--- a/TournamentAPI.Shared/Models/ResponseModels.cs
+++ b/TournamentAPI.Shared/Models/ResponseModels.cs
@@ -193,6 +193,16 @@ public class RegisterUserResult
     public bool? Boolean { get; set; }
 }
 
+public class RefreshTokenResponse
+{
+    public RefreshTokenResult? RefreshToken { get; set; }
+}
+
+public class RefreshTokenResult
+{
+    public string? String { get; set; }
+}
+
 public class MeResponse
 {
     public UserNode? Me { get; set; }

--- a/TournamentAPI.Shared/MutationExamples/UserMutations.cs
+++ b/TournamentAPI.Shared/MutationExamples/UserMutations.cs
@@ -18,5 +18,13 @@ public static partial class Mutations
               }
             }
             """;
+
+        public const string RefreshToken = """
+            mutation RefreshToken {
+              refreshToken {
+                string
+              }
+            }
+            """;
     }
 }

--- a/TournamentAPI/Data/ApplicationDbContext.cs
+++ b/TournamentAPI/Data/ApplicationDbContext.cs
@@ -15,6 +15,7 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser, IdentityR
     public DbSet<TournamentParticipant> TournamentParticipants { get; set; }
     public DbSet<Bracket> Brackets { get; set; }
     public DbSet<Match> Matches { get; set; }
+    public DbSet<RefreshToken> RefreshTokens { get; set; }
 
     protected override void OnModelCreating(ModelBuilder builder)
     {
@@ -93,5 +94,15 @@ public class ApplicationDbContext : IdentityDbContext<ApplicationUser, IdentityR
         builder.Entity<Match>()
             .HasIndex(m => new { m.BracketId, m.Round, m.Player1Id, m.Player2Id })
             .IsUnique();
+
+        builder.Entity<RefreshToken>().HasKey(e => e.Id);
+        builder.Entity<RefreshToken>()
+            .HasIndex(e => e.Token)
+            .IsUnique();
+
+        builder.Entity<RefreshToken>()
+            .HasOne(e => e.User)
+            .WithMany()
+            .HasForeignKey(e => e.UserId);
     }
 }

--- a/TournamentAPI/Data/Models/RefreshToken.cs
+++ b/TournamentAPI/Data/Models/RefreshToken.cs
@@ -1,0 +1,10 @@
+namespace TournamentAPI.Data.Models;
+
+public class RefreshToken
+{
+    public Guid Id { get; set; }
+    public string Token { get; set; } = null!;
+    public DateTime ExpiryDateUtc { get; set; }
+    public int UserId { get; set; }
+    public ApplicationUser User { get; set; } = null!;
+}

--- a/TournamentAPI/Extensions/HttpResponseExtensions.cs
+++ b/TournamentAPI/Extensions/HttpResponseExtensions.cs
@@ -1,0 +1,18 @@
+namespace TournamentAPI.Extensions;
+
+public static class HttpResponseExtensions
+{
+    public static void AppendRefreshTokenCookie(this HttpResponse response, string token, DateTime expiry)
+    {
+        response.Cookies.Append(
+            "refreshToken",
+            token,
+            new CookieOptions
+            {
+                HttpOnly = true,
+                Secure = true,
+                SameSite = SameSiteMode.Lax,
+                Expires = expiry
+            });
+    }
+}

--- a/TournamentAPI/Program.cs
+++ b/TournamentAPI/Program.cs
@@ -109,6 +109,7 @@ builder.Services.AddAuthorizationBuilder()
         .RequireAuthenticatedUser().Build());
 
 builder.Services
+    .AddHttpContextAccessor()
     .AddGraphQLServer()
     .AddHttpRequestInterceptor<HttpRequestInterceptor>()
     .AddDiagnosticEventListener<ExecutionEventListener>()

--- a/TournamentAPI/Services/JwtService.cs
+++ b/TournamentAPI/Services/JwtService.cs
@@ -1,6 +1,7 @@
 using Microsoft.IdentityModel.Tokens;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using System.Security.Cryptography;
 using System.Text;
 using TournamentAPI.Data.Models;
 
@@ -28,6 +29,11 @@ public class JwtService
         var tokenHandler = new JwtSecurityTokenHandler();
 
         return tokenHandler.WriteToken(token);
+    }
+
+    public string CreateRefreshToken()
+    {
+        return Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
     }
 
     private JwtSecurityToken CreateJwtToken(Claim[] claims, SigningCredentials credentials, DateTime expiration)

--- a/TournamentAPI/Users/UserErrorCodes.cs
+++ b/TournamentAPI/Users/UserErrorCodes.cs
@@ -5,4 +5,7 @@ public static class UserErrorCodes
     public const string UserNotFound = "User.NotFound";
     public const string InvalidCredentials = "User.InvalidCredentials";
     public const string RegistrationFailed = "User.RegistrationFailed";
+    public const string RefreshTokenExpired = "User.RefreshTokenExpired";
+    public const string RefreshTokenInvalid = "User.RefreshTokenInvalid";
+    public const string UnableToSetRefreshTokenCookie = "User.UnableToSetRefreshTokenCookie";
 }

--- a/TournamentAPI/Users/UserErrors.cs
+++ b/TournamentAPI/Users/UserErrors.cs
@@ -21,4 +21,22 @@ public static class UserErrors
             .SetCode(UserErrorCodes.RegistrationFailed)
             .SetExtension("Errors", errors)
             .Build();
+
+    public static IError RefreshTokenExpired() =>
+        ErrorBuilder.New()
+            .SetMessage("The refresh token has expired.")
+            .SetCode(UserErrorCodes.RefreshTokenExpired)
+            .Build();
+
+    public static IError RefreshTokenInvalid() =>
+        ErrorBuilder.New()
+            .SetMessage("The refresh token is invalid.")
+            .SetCode(UserErrorCodes.RefreshTokenInvalid)
+            .Build();
+
+    public static IError UnableToSetRefreshTokenCookie() =>
+        ErrorBuilder.New()
+            .SetMessage("Unable to set refresh token cookie.")
+            .SetCode(UserErrorCodes.UnableToSetRefreshTokenCookie)
+            .Build();
 }

--- a/TournamentAPI/Users/UserMutations.cs
+++ b/TournamentAPI/Users/UserMutations.cs
@@ -33,6 +33,8 @@ public class UserMutations
     public async Task<string?> LoginUser(
         LoginUserInput input,
         UserManager<ApplicationUser> userManager,
+        ApplicationDbContext context,
+        IHttpContextAccessor httpContextAccessor,
         IResolverContext resolverContext,
         JwtService jwtService)
     {
@@ -44,6 +46,38 @@ public class UserMutations
         if (!await userManager.CheckPasswordAsync(user, input.Password))
         {
             resolverContext.ReportError(UserErrors.InvalidCredentials());
+            return null;
+        }
+
+        var accessToken = jwtService.CreateToken(user);
+        var refreshToken = new RefreshToken
+        {
+            Id = Guid.NewGuid(),
+            UserId = user.Id,
+            Token = jwtService.CreateRefreshToken(),
+            ExpiryDateUtc = DateTime.UtcNow.AddDays(7),
+        };
+
+        if (httpContextAccessor.HttpContext == null)
+        {
+            resolverContext.ReportError(UserErrors.UnableToSetRefreshTokenCookie());
+            return null;
+        }
+
+        await context.RefreshTokens
+            .Where(r => r.UserId == user.Id)
+            .ExecuteDeleteAsync();
+
+        context.RefreshTokens.Add(refreshToken);
+        await context.SaveChangesAsync();
+
+        httpContextAccessor.HttpContext.Response.AppendRefreshTokenCookie(refreshToken.Token, refreshToken.ExpiryDateUtc);
+
+        return accessToken;
+    }
+        if (httpContextAccessor.HttpContext == null)
+        {
+            resolverContext.ReportError(UserErrors.UnableToSetRefreshTokenCookie());
             return null;
         }
 

--- a/TournamentAPI/Users/UserMutations.cs
+++ b/TournamentAPI/Users/UserMutations.cs
@@ -1,5 +1,7 @@
 using HotChocolate.Resolvers;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using TournamentAPI.Data;
 using TournamentAPI.Data.Models;
 using TournamentAPI.Extensions;
 using TournamentAPI.Services;
@@ -75,13 +77,46 @@ public class UserMutations
 
         return accessToken;
     }
+
+    public async Task<string?> RefreshToken(
+        JwtService jwtService,
+        ApplicationDbContext context,
+        IResolverContext resolverContext,
+        IHttpContextAccessor httpContextAccessor
+    )
+    {
         if (httpContextAccessor.HttpContext == null)
         {
             resolverContext.ReportError(UserErrors.UnableToSetRefreshTokenCookie());
             return null;
         }
 
-        var token = jwtService.CreateToken(user);
-        return token;
+        var refreshToken = httpContextAccessor.HttpContext.Request.Cookies["refreshToken"];
+
+        var refreshTokenEntity = await context.RefreshTokens
+            .Include(r => r.User)
+            .FirstOrDefaultAsync(r => r.Token == refreshToken);
+
+        if (refreshTokenEntity is null)
+        {
+            resolverContext.ReportError(UserErrors.RefreshTokenInvalid());
+            return null;
+        }
+
+        if (refreshTokenEntity.ExpiryDateUtc < DateTime.UtcNow)
+        {
+            resolverContext.ReportError(UserErrors.RefreshTokenExpired());
+            return null;
+        }
+
+        string accessToken = jwtService.CreateToken(refreshTokenEntity.User);
+        refreshTokenEntity.Token = jwtService.CreateRefreshToken();
+        refreshTokenEntity.ExpiryDateUtc = DateTime.UtcNow.AddDays(7);
+
+        await context.SaveChangesAsync();
+
+        httpContextAccessor.HttpContext.Response.AppendRefreshTokenCookie(refreshTokenEntity.Token, refreshTokenEntity.ExpiryDateUtc);
+
+        return accessToken;
     }
 }

--- a/docs/adr/0003_refresh_token_storage.md
+++ b/docs/adr/0003_refresh_token_storage.md
@@ -1,0 +1,23 @@
+# Title
+Refresh Token Storage Strategy
+
+# Date
+22/03/2026
+
+## Status
+Accepted
+
+## Context
+When implementing refresh tokens for JWT authentication, a decision was needed on how to deliver and store the refresh token on the client side. The access token (short-lived, 10-minute expiration) is returned in the response body. The refresh token must be stored somewhere accessible to the client for subsequent token renewal requests, while minimizing exposure to theft.
+
+## Considered Options
+1. Return both access token and refresh token in the response body
+   - Pros: Simple to implement; client has full control over token storage.
+   - Cons: Refresh token is accessible to JavaScript, making it vulnerable to XSS attacks. Client must manage secure storage (e.g., localStorage is insecure, in-memory storage is lost on page refresh).
+2. Return access token in the response body and refresh token in an HTTP-only cookie
+   - Pros: HTTP-only cookies are inaccessible to JavaScript, significantly reducing XSS attack surface. Browser handles storage and automatically sends the cookie on requests to the same origin.
+   - Cons: Requires CSRF protection considerations; slightly more complex to implement server-side cookie handling.
+
+## Decision
+
+We decided to return the access token in the response body and the refresh token in an HTTP-only cookie. The HTTP-only flag prevents JavaScript from reading the cookie, protecting the refresh token from XSS-based token theft. This is the more secure approach and aligns with security best practices for token storage.


### PR DESCRIPTION
#### Summary
Adds refresh token issuance, storage, rotation, and validation using HTTP-only cookies for enhanced authentication security, along with supporting tests and documentation.

#### Changes
- UserMutations.cs: Implements refresh token logic in login and refresh mutations, including cookie handling and token rotation.
- ApplicationDbContext.cs and RefreshToken.cs: Adds RefreshToken entity and database integration.
- TestClient.cs and UserMutationTests.cs: Adds integration tests for refresh token flows and cookie management.
- JwtService.cs: Adds refresh token generation method.
- 0003_refresh_token_storage.md: Documents the decision to use HTTP-only cookies for refresh token storage.
