### PR TITLE
feat: add OpenTelemetry

### DIFF
--- a/TournamentAPI/Program.cs
+++ b/TournamentAPI/Program.cs
@@ -4,6 +4,10 @@ using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
+using OpenTelemetry.Logs;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Resources;
+using OpenTelemetry.Trace;
 using Serilog;
 using System.Text;
 using System.Threading.RateLimiting;
@@ -82,6 +86,21 @@ builder.Services.AddRateLimiter(options =>
     });
 });
 
+builder.Services.AddOpenTelemetry()
+    .ConfigureResource(resource => resource.AddService("TournamentAPI"))
+    .WithTracing(tracing =>
+    {
+        tracing.AddHttpClientInstrumentation();
+        tracing.AddAspNetCoreInstrumentation();
+        tracing.AddHotChocolateInstrumentation();
+        tracing.AddConsoleExporter();
+    })
+    .WithMetrics(metrics =>
+    {
+        metrics.AddAspNetCoreInstrumentation();
+        metrics.AddConsoleExporter();
+    });
+
 builder.Services
     .AddAuthentication(options =>
     {
@@ -136,7 +155,8 @@ builder.Services
     .AddProjections()
     .AddFiltering()
     .AddSorting()
-    .AddMaxExecutionDepthRule(8);
+    .AddMaxExecutionDepthRule(8)
+    .AddInstrumentation();
 
 builder.Services.AddScoped<JwtService>();
 

--- a/TournamentAPI/TournamentAPI.csproj
+++ b/TournamentAPI/TournamentAPI.csproj
@@ -7,9 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HotChocolate.AspNetCore" Version="15.1.11" />
-    <PackageReference Include="HotChocolate.AspNetCore.Authorization" Version="15.1.11" />
-    <PackageReference Include="HotChocolate.Data.EntityFramework" Version="15.1.11" />
+    <PackageReference Include="HotChocolate.AspNetCore" Version="15.1.14" />
+    <PackageReference Include="HotChocolate.AspNetCore.Authorization" Version="15.1.14" />
+    <PackageReference Include="HotChocolate.Data.EntityFramework" Version="15.1.14" />
+    <PackageReference Include="HotChocolate.Diagnostics" Version="15.1.14" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.11" />
     <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.11" />
@@ -19,6 +20,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.11" />
+    <PackageReference Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
   </ItemGroup>


### PR DESCRIPTION
#### Summary
This pull request adds OpenTelemetry-based tracing and metrics, upgrades HotChocolate packages, and enables enhanced diagnostics for the GraphQL server.

#### Changes
- Program.cs: Registers and configures OpenTelemetry for tracing and metrics, including instrumentation for ASP.NET Core, HTTP client, and HotChocolate, and enables console exporters.
- Program.cs: Enables HotChocolate server instrumentation via .AddInstrumentation().
- TournamentAPI.csproj: Upgrades HotChocolate packages to 15.1.14, adds HotChocolate.Diagnostics, and includes OpenTelemetry-related NuGet packages.
