### PR TITLE
feat: implement refresh token hashing

### DIFF
--- a/TournamentAPI.IntegrationTests/GraphQL/Tests/Users/UserMutationTests.cs
+++ b/TournamentAPI.IntegrationTests/GraphQL/Tests/Users/UserMutationTests.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using Microsoft.EntityFrameworkCore;
 using TournamentAPI.Data.Models;
 using TournamentAPI.Shared.Extensions;
@@ -286,18 +288,20 @@ public class UserMutationTests : BaseIntegrationTest
     public async Task RefreshToken_ReturnsExpiredError_WhenTokenIsExpired()
     {
         var alice = await DbContext.Users.FirstAsync(u => u.Email == "alice@example.com");
+        var rawToken = "expired-token-value";
+        var hashedToken = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(rawToken))).ToLowerInvariant();
         var expiredToken = new RefreshToken
         {
             Id = Guid.NewGuid(),
             UserId = alice.Id,
-            Token = "expired-token-value",
+            Token = hashedToken,
             ExpiryDateUtc = DateTime.UtcNow.AddDays(-1)
         };
         DbContext.RefreshTokens.Add(expiredToken);
         await DbContext.SaveChangesAsync();
 
         using var client = CreateClient();
-        client.SetRefreshTokenCookie(expiredToken.Token);
+        client.SetRefreshTokenCookie(rawToken);
 
         var response = await client.ExecuteMutationAsync<RefreshTokenResponse>(
             Shared.MutationExamples.Mutations.Users.RefreshToken,

--- a/TournamentAPI.UnitTests/Services/JwtServiceTests.cs
+++ b/TournamentAPI.UnitTests/Services/JwtServiceTests.cs
@@ -115,6 +115,34 @@ public class JwtServiceTests
         Assert.Equal("42", nameIdClaim.Value);
     }
 
+    [Fact]
+    public void HashRefreshToken_ReturnsNonEmptyString()
+    {
+        var hash = _sut.HashRefreshToken("some-token");
+
+        Assert.False(string.IsNullOrEmpty(hash));
+    }
+
+    [Fact]
+    public void HashRefreshToken_IsDeterministic()
+    {
+        var token = "some-token";
+
+        var hash1 = _sut.HashRefreshToken(token);
+        var hash2 = _sut.HashRefreshToken(token);
+
+        Assert.Equal(hash1, hash2);
+    }
+
+    [Fact]
+    public void HashRefreshToken_ReturnsDifferentHashesForDifferentTokens()
+    {
+        var hash1 = _sut.HashRefreshToken("token-one");
+        var hash2 = _sut.HashRefreshToken("token-two");
+
+        Assert.NotEqual(hash1, hash2);
+    }
+
     private static ApplicationUser CreateTestUser(int id = 1, string userName = "testuser", string email = "test@example.com")
         => new()
         {

--- a/TournamentAPI/Services/JwtService.cs
+++ b/TournamentAPI/Services/JwtService.cs
@@ -31,9 +31,16 @@ public class JwtService
         return tokenHandler.WriteToken(token);
     }
 
-    public string CreateRefreshToken()
+    public RefreshTokenResult CreateRefreshToken()
     {
-        return Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+        var raw = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32));
+        return new RefreshTokenResult(raw, HashRefreshToken(raw));
+    }
+
+    public string HashRefreshToken(string token)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(token));
+        return Convert.ToHexString(bytes).ToLowerInvariant();
     }
 
     private JwtSecurityToken CreateJwtToken(Claim[] claims, SigningCredentials credentials, DateTime expiration)

--- a/TournamentAPI/Services/RefreshTokenResult.cs
+++ b/TournamentAPI/Services/RefreshTokenResult.cs
@@ -1,0 +1,3 @@
+namespace TournamentAPI.Services;
+
+public record RefreshTokenResult(string Raw, string Hashed);

--- a/TournamentAPI/Users/UserMutations.cs
+++ b/TournamentAPI/Users/UserMutations.cs
@@ -52,11 +52,12 @@ public class UserMutations
         }
 
         var accessToken = jwtService.CreateToken(user);
+        var refreshTokenResult = jwtService.CreateRefreshToken();
         var refreshToken = new RefreshToken
         {
             Id = Guid.NewGuid(),
             UserId = user.Id,
-            Token = jwtService.CreateRefreshToken(),
+            Token = refreshTokenResult.Hashed,
             ExpiryDateUtc = DateTime.UtcNow.AddDays(7),
         };
 
@@ -73,7 +74,7 @@ public class UserMutations
         context.RefreshTokens.Add(refreshToken);
         await context.SaveChangesAsync();
 
-        httpContextAccessor.HttpContext.Response.AppendRefreshTokenCookie(refreshToken.Token, refreshToken.ExpiryDateUtc);
+        httpContextAccessor.HttpContext.Response.AppendRefreshTokenCookie(refreshTokenResult.Raw, refreshToken.ExpiryDateUtc);
 
         return accessToken;
     }
@@ -91,11 +92,12 @@ public class UserMutations
             return null;
         }
 
-        var refreshToken = httpContextAccessor.HttpContext.Request.Cookies["refreshToken"];
+        var rawCookieToken = httpContextAccessor.HttpContext.Request.Cookies["refreshToken"];
+        var hashedCookieToken = jwtService.HashRefreshToken(rawCookieToken ?? string.Empty);
 
         var refreshTokenEntity = await context.RefreshTokens
             .Include(r => r.User)
-            .FirstOrDefaultAsync(r => r.Token == refreshToken);
+            .FirstOrDefaultAsync(r => r.Token == hashedCookieToken);
 
         if (refreshTokenEntity is null)
         {
@@ -110,12 +112,13 @@ public class UserMutations
         }
 
         string accessToken = jwtService.CreateToken(refreshTokenEntity.User);
-        refreshTokenEntity.Token = jwtService.CreateRefreshToken();
+        var newRefreshToken = jwtService.CreateRefreshToken();
+        refreshTokenEntity.Token = newRefreshToken.Hashed;
         refreshTokenEntity.ExpiryDateUtc = DateTime.UtcNow.AddDays(7);
 
         await context.SaveChangesAsync();
 
-        httpContextAccessor.HttpContext.Response.AppendRefreshTokenCookie(refreshTokenEntity.Token, refreshTokenEntity.ExpiryDateUtc);
+        httpContextAccessor.HttpContext.Response.AppendRefreshTokenCookie(newRefreshToken.Raw, refreshTokenEntity.ExpiryDateUtc);
 
         return accessToken;
     }


### PR DESCRIPTION
#### Summary
This PR updates the refresh token mechanism to store only hashed tokens in the database, improving security and aligning with best practices. The raw token is now only present in the user's cookie, and all related logic and tests have been updated accordingly.

#### Changes
- JwtService: Added HashRefreshToken method and updated CreateRefreshToken to return both raw and hashed tokens.
- UserMutations: Now stores hashed refresh tokens in the database, sets raw tokens in cookies, and validates by hashing the cookie value.
- JwtServiceTests: Added tests for refresh token hashing and updated existing tests to reflect the new logic.
- UserMutationTests: Updated to hash tokens before storing and to use raw tokens in cookies.
- Introduced RefreshTokenResult record to encapsulate raw and hashed token values.
