### PR TITLE
feat: add health checks

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,6 +3,8 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="AspNetCore.HealthChecks.SqlServer" Version="9.0.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
     <PackageVersion Include="HotChocolate.AspNetCore" Version="15.1.15" />
     <PackageVersion Include="HotChocolate.AspNetCore.Authorization" Version="15.1.14" />
     <PackageVersion Include="HotChocolate.Data.EntityFramework" Version="15.1.14" />
@@ -13,17 +15,16 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.11" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.11" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="9.0.11" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
     <PackageVersion Include="Serilog" Version="4.3.0" />
     <PackageVersion Include="Serilog.Sinks.Console" Version="6.1.1" />
-
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="Bogus" Version="35.6.5" />
     <PackageVersion Include="NBomber" Version="6.1.2" />
-
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.11" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />

--- a/TournamentAPI/Program.cs
+++ b/TournamentAPI/Program.cs
@@ -1,8 +1,11 @@
+using HealthChecks.UI.Client;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.IdentityModel.Tokens;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
@@ -123,9 +126,32 @@ builder.Services
         };
     });
 
+builder.Services
+    .AddHealthChecks()
+    .AddSqlServer(
+        connectionString: builder.Configuration.GetConnectionString("DefaultConnection"),
+        name: "sqlserver",
+        tags: ["database"],
+        failureStatus: HealthStatus.Unhealthy
+    )
+    .AddDbContextCheck<ApplicationDbContext>(
+        name: "database",
+        tags: ["database"],
+        failureStatus: HealthStatus.Unhealthy
+    );
+
 builder.Services.AddAuthorizationBuilder()
     .SetDefaultPolicy(new AuthorizationPolicyBuilder(JwtBearerDefaults.AuthenticationScheme)
-        .RequireAuthenticatedUser().Build());
+        .RequireAuthenticatedUser().Build())
+    .AddPolicy("HealthCheckPolicy", policy =>
+        policy.RequireAssertion(context =>
+        {
+            var httpContext = context.Resource as HttpContext;
+            var apiKey = httpContext?.Request.Headers["X-Health-Check-Key"].ToString();
+            var expectedKey = builder.Configuration["HealthCheck:ApiKey"];
+
+            return apiKey == expectedKey;
+        }));
 
 builder.Services
     .AddHttpContextAccessor()
@@ -181,6 +207,13 @@ app.UseRouting();
 
 app.UseAuthentication();
 app.UseAuthorization();
+
+app.MapHealthChecks("/health", new HealthCheckOptions
+{
+    ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
+})
+.RequireAuthorization("HealthCheckPolicy")
+.RequireRateLimiting("IpBasedTokenBucket");
 
 app.MapGraphQL()
     .RequireRateLimiting("IpBasedTokenBucket");

--- a/TournamentAPI/Program.cs
+++ b/TournamentAPI/Program.cs
@@ -12,6 +12,7 @@ using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
 using Serilog;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading.RateLimiting;
 using TournamentAPI;
@@ -150,7 +151,15 @@ builder.Services.AddAuthorizationBuilder()
             var apiKey = httpContext?.Request.Headers["X-Health-Check-Key"].ToString();
             var expectedKey = builder.Configuration["HealthCheck:ApiKey"];
 
-            return apiKey == expectedKey;
+            if (string.IsNullOrEmpty(apiKey) || string.IsNullOrEmpty(expectedKey))
+            {
+                return false;
+            }
+
+            var apiKeySpan = Encoding.UTF8.GetBytes(apiKey).AsSpan();
+            var expectedKeySpan = Encoding.UTF8.GetBytes(expectedKey).AsSpan();
+
+            return CryptographicOperations.FixedTimeEquals(apiKeySpan, expectedKeySpan);
         }));
 
 builder.Services

--- a/TournamentAPI/TournamentAPI.csproj
+++ b/TournamentAPI/TournamentAPI.csproj
@@ -7,6 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.SqlServer" />
+    <PackageReference Include="AspNetCore.HealthChecks.UI.Client" />
     <PackageReference Include="HotChocolate.AspNetCore" />
     <PackageReference Include="HotChocolate.AspNetCore.Authorization" />
     <PackageReference Include="HotChocolate.Data.EntityFramework" />
@@ -20,6 +22,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />

--- a/TournamentAPI/appsettings.json
+++ b/TournamentAPI/appsettings.json
@@ -14,5 +14,8 @@
     "Audience": "api.programowaniezaawansowane.va",
     "Subject": "JWT for api.programowaniezaawansowane.va"
   },
+  "HealthCheck": {
+    "ApiKey": ""
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
#### Summary
This pull request adds health check endpoints with API key protection and rate limiting, and updates configuration and dependencies accordingly.

#### Changes
- Program.cs: Configures SQL Server and DbContext health checks, adds a /health endpoint, enforces API key authorization, and applies rate limiting.
- appsettings.json: Adds a HealthCheck section with an ApiKey for securing health check requests.
- Directory.Packages.props & TournamentAPI.csproj: Adds health check-related packages