### PR TITLE
refactor: replace IConfiguration with options pattern

### DIFF
--- a/TournamentAPI.UnitTests/Services/JwtServiceTests.cs
+++ b/TournamentAPI.UnitTests/Services/JwtServiceTests.cs
@@ -1,6 +1,7 @@
-using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Options;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
+using TournamentAPI.Configuration;
 using TournamentAPI.Data.Models;
 using TournamentAPI.Services;
 
@@ -9,20 +10,17 @@ namespace TournamentAPI.UnitTests.Services;
 public class JwtServiceTests
 {
     private readonly JwtService _sut;
-    private readonly IConfiguration _configuration;
 
     public JwtServiceTests()
     {
-        _configuration = new ConfigurationBuilder()
-            .AddInMemoryCollection(new Dictionary<string, string?>
-            {
-                ["Jwt:Issuer"] = "test-issuer",
-                ["Jwt:Audience"] = "test-audience",
-                ["Jwt:Key"] = "test-secret-key-that-is-at-least-32-bytes-long!"
-            })
-            .Build();
+        var jwtOptions = Options.Create(new JwtOptions
+        {
+            Issuer = "test-issuer",
+            Audience = "test-audience",
+            Key = "test-secret-key-that-is-at-least-32-bytes-long!"
+        });
 
-        _sut = new JwtService(_configuration);
+        _sut = new JwtService(jwtOptions);
     }
 
     [Fact]

--- a/TournamentAPI/Configuration/DatabaseOptions.cs
+++ b/TournamentAPI/Configuration/DatabaseOptions.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TournamentAPI.Configuration;
+
+public record DatabaseOptions
+{
+    public const string SectionName = "ConnectionStrings";
+
+    [Required]
+    public string DefaultConnection { get; init; } = string.Empty;
+}

--- a/TournamentAPI/Configuration/HealthCheckApiKeyOptions.cs
+++ b/TournamentAPI/Configuration/HealthCheckApiKeyOptions.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TournamentAPI.Configuration;
+
+public record HealthCheckApiKeyOptions
+{
+    public const string SectionName = "HealthCheck";
+
+    [Required]
+    public string ApiKey { get; init; } = string.Empty;
+}

--- a/TournamentAPI/Configuration/JwtOptions.cs
+++ b/TournamentAPI/Configuration/JwtOptions.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TournamentAPI.Configuration;
+
+public record JwtOptions
+{
+    public const string SectionName = "Jwt";
+
+    [Required]
+    public string Key { get; init; } = string.Empty;
+
+    [Required]
+    public string Issuer { get; init; } = string.Empty;
+
+    [Required]
+    public string Audience { get; init; } = string.Empty;
+
+    public string Subject { get; init; } = string.Empty;
+}

--- a/TournamentAPI/Program.cs
+++ b/TournamentAPI/Program.cs
@@ -33,6 +33,24 @@ Log.Logger = new LoggerConfiguration()
     .WriteTo.Console()
     .CreateLogger();
 
+builder.Services
+    .AddOptions<JwtOptions>()
+    .BindConfiguration(JwtOptions.SectionName)
+    .ValidateDataAnnotations()
+    .ValidateOnStart();
+
+builder.Services
+    .AddOptions<DatabaseOptions>()
+    .BindConfiguration(DatabaseOptions.SectionName)
+    .ValidateDataAnnotations()
+    .ValidateOnStart();
+
+builder.Services
+    .AddOptions<HealthCheckApiKeyOptions>()
+    .BindConfiguration(HealthCheckApiKeyOptions.SectionName)
+    .ValidateDataAnnotations()
+    .ValidateOnStart();
+
 if (builder.Environment.IsDevelopment())
 {
     builder.Services.Configure<ForwardedHeadersOptions>(options =>

--- a/TournamentAPI/Program.cs
+++ b/TournamentAPI/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Metrics;
@@ -17,6 +18,7 @@ using System.Text;
 using System.Threading.RateLimiting;
 using TournamentAPI;
 using TournamentAPI.Brackets;
+using TournamentAPI.Configuration;
 using TournamentAPI.Data;
 using TournamentAPI.Data.Models;
 using TournamentAPI.EventListeners;
@@ -62,9 +64,10 @@ if (builder.Environment.IsDevelopment())
     });
 }
 
-builder.Services.AddDbContextFactory<ApplicationDbContext>(options =>
+builder.Services.AddDbContextFactory<ApplicationDbContext>((sp, options) =>
 {
-    options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection"));
+    var dbOptions = sp.GetRequiredService<IOptions<DatabaseOptions>>().Value;
+    options.UseSqlServer(dbOptions.DefaultConnection);
 });
 
 builder.Services.AddIdentity<ApplicationUser, IdentityRole<int>>(opt =>
@@ -129,26 +132,29 @@ builder.Services
         options.DefaultAuthenticateScheme = JwtBearerDefaults.AuthenticationScheme;
         options.DefaultChallengeScheme = JwtBearerDefaults.AuthenticationScheme;
     })
-    .AddJwtBearer(options =>
+    .AddJwtBearer();
+
+builder.Services
+    .AddOptions<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme)
+    .Configure<IOptions<JwtOptions>>((jwtBearerOptions, jwtOpts) =>
     {
-        options.TokenValidationParameters = new()
+        var jwt = jwtOpts.Value;
+        jwtBearerOptions.TokenValidationParameters = new TokenValidationParameters
         {
             ValidateIssuer = true,
             ValidateAudience = true,
             ValidateLifetime = true,
             ValidateIssuerSigningKey = true,
-            ValidAudience = builder.Configuration["Jwt:Audience"] ?? throw new InvalidOperationException("JWT Audience is not configured."),
-            ValidIssuer = builder.Configuration["Jwt:Issuer"] ?? throw new InvalidOperationException("JWT Issuer is not configured."),
-            IssuerSigningKey = new SymmetricSecurityKey(
-                Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"] ?? throw new InvalidOperationException("JWT Key is not configured."))
-            )
+            ValidAudience = jwt.Audience,
+            ValidIssuer = jwt.Issuer,
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwt.Key))
         };
     });
 
 builder.Services
     .AddHealthChecks()
     .AddSqlServer(
-        connectionString: builder.Configuration.GetConnectionString("DefaultConnection"),
+        connectionStringFactory: sp => sp.GetRequiredService<IOptions<DatabaseOptions>>().Value.DefaultConnection,
         name: "sqlserver",
         tags: ["database"],
         failureStatus: HealthStatus.Unhealthy
@@ -167,7 +173,9 @@ builder.Services.AddAuthorizationBuilder()
         {
             var httpContext = context.Resource as HttpContext;
             var apiKey = httpContext?.Request.Headers["X-Health-Check-Key"].ToString();
-            var expectedKey = builder.Configuration["HealthCheck:ApiKey"];
+            var expectedKey = httpContext?.RequestServices
+                .GetRequiredService<IOptions<HealthCheckApiKeyOptions>>()
+                .Value.ApiKey;
 
             if (string.IsNullOrEmpty(apiKey) || string.IsNullOrEmpty(expectedKey))
             {

--- a/TournamentAPI/Services/JwtService.cs
+++ b/TournamentAPI/Services/JwtService.cs
@@ -1,19 +1,21 @@
+using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using System.IdentityModel.Tokens.Jwt;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
+using TournamentAPI.Configuration;
 using TournamentAPI.Data.Models;
 
 namespace TournamentAPI.Services;
 
 public class JwtService
 {
-    private readonly IConfiguration _configuration;
+    private readonly JwtOptions _jwtOptions;
 
-    public JwtService(IConfiguration configuration)
+    public JwtService(IOptions<JwtOptions> jwtOptions)
     {
-        _configuration = configuration;
+        _jwtOptions = jwtOptions.Value;
     }
 
     public string CreateToken(ApplicationUser user)
@@ -46,8 +48,8 @@ public class JwtService
     private JwtSecurityToken CreateJwtToken(Claim[] claims, SigningCredentials credentials, DateTime expiration)
     {
         return new JwtSecurityToken(
-            _configuration["Jwt:Issuer"],
-            _configuration["Jwt:Audience"],
+            _jwtOptions.Issuer,
+            _jwtOptions.Audience,
             claims,
             expires: expiration,
             signingCredentials: credentials
@@ -71,9 +73,7 @@ public class JwtService
     private SigningCredentials CreateSigningCredentials()
     {
         return new SigningCredentials(
-            new SymmetricSecurityKey(
-                    Encoding.UTF8.GetBytes(_configuration["Jwt:Key"] ?? throw new InvalidOperationException("JWT Key is not configured."))
-            ),
+            new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_jwtOptions.Key)),
             SecurityAlgorithms.HmacSha256
         );
     }


### PR DESCRIPTION
#### Summary
This pull request replaces direct IConfiguration access with strongly-typed options classes and updates service registrations and dependencies accordingly for better maintainability and validation.

#### Changes
- Program.cs: Registers and validates JwtOptions, DatabaseOptions, and HealthCheckApiKeyOptions; updates DI usage for DbContext, JWT authentication, and health check policy.
- JwtService.cs: Refactored to use IOptions<JwtOptions> for JWT creation.
- JwtServiceTests.cs: Updated to use Options.Create<JwtOptions> for test setup.
- Added JwtOptions.cs, DatabaseOptions.cs, and HealthCheckApiKeyOptions.cs to define and validate configuration sections.
