### PR TITLE
feat: add custom metrics for tournaments

### DIFF
--- a/TournamentAPI/Metrics/MetricConstants.cs
+++ b/TournamentAPI/Metrics/MetricConstants.cs
@@ -1,0 +1,6 @@
+namespace TournamentAPI.Metrics;
+
+public static class MetricConstants
+{
+    public const string TournamentMeterName = "TournamentAPI.Tournaments";
+}

--- a/TournamentAPI/Metrics/TournamentMetrics.cs
+++ b/TournamentAPI/Metrics/TournamentMetrics.cs
@@ -1,21 +1,39 @@
 using System.Diagnostics.Metrics;
+using TournamentAPI.Data;
+using TournamentAPI.Data.Models;
 
 namespace TournamentAPI.Metrics;
 
 public class TournamentMetrics : IHostedService
 {
+    private readonly IServiceScopeFactory _serviceScopeFactory;
     private readonly Counter<int> _tournamentsCreated;
 
-    public TournamentMetrics(IMeterFactory meterFactory)
+    public TournamentMetrics(IMeterFactory meterFactory, IServiceScopeFactory serviceScopeFactory)
     {
+        _serviceScopeFactory = serviceScopeFactory;
+
         var meter = meterFactory.Create(MetricConstants.TournamentMeterName);
         _tournamentsCreated = meter.CreateCounter<int>("tournamentapi.tournaments.tournaments_created", description: "Number of tournaments created");
+
+        _ = meter.CreateObservableGauge(
+            "tournamentapi.tournaments.active_tournaments",
+            () => GetActiveTournamentsCount(),
+            description: "Number of currently active tournaments");
     }
 
     public void IncrementTournamentsCreated()
     {
         _tournamentsCreated.Add(1);
     }
+
+    private int GetActiveTournamentsCount()
+    {
+        using var scope = _serviceScopeFactory.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        return context.Tournaments.Count(t => t.Status == TournamentStatus.Open);
+    }
+
     public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 
     public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;

--- a/TournamentAPI/Metrics/TournamentMetrics.cs
+++ b/TournamentAPI/Metrics/TournamentMetrics.cs
@@ -1,0 +1,19 @@
+using System.Diagnostics.Metrics;
+
+namespace TournamentAPI.Metrics;
+
+public class TournamentMetrics
+{
+    private readonly Counter<int> _tournamentsCreated;
+
+    public TournamentMetrics(IMeterFactory meterFactory)
+    {
+        var meter = meterFactory.Create(MetricConstants.TournamentMeterName);
+        _tournamentsCreated = meter.CreateCounter<int>("tournamentapi.tournaments.tournaments_created", description: "Number of tournaments created");
+    }
+
+    public void IncrementTournamentsCreated()
+    {
+        _tournamentsCreated.Add(1);
+    }
+}

--- a/TournamentAPI/Metrics/TournamentMetrics.cs
+++ b/TournamentAPI/Metrics/TournamentMetrics.cs
@@ -2,7 +2,7 @@ using System.Diagnostics.Metrics;
 
 namespace TournamentAPI.Metrics;
 
-public class TournamentMetrics
+public class TournamentMetrics : IHostedService
 {
     private readonly Counter<int> _tournamentsCreated;
 
@@ -16,4 +16,7 @@ public class TournamentMetrics
     {
         _tournamentsCreated.Add(1);
     }
+    public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
 }

--- a/TournamentAPI/Program.cs
+++ b/TournamentAPI/Program.cs
@@ -23,6 +23,7 @@ using TournamentAPI.Data;
 using TournamentAPI.Data.Models;
 using TournamentAPI.EventListeners;
 using TournamentAPI.Matches;
+using TournamentAPI.Metrics;
 using TournamentAPI.Participants;
 using TournamentAPI.Services;
 using TournamentAPI.Tournaments;
@@ -122,6 +123,7 @@ builder.Services.AddOpenTelemetry()
     })
     .WithMetrics(metrics =>
     {
+        metrics.AddMeter(MetricConstants.TournamentMeterName);
         metrics.AddAspNetCoreInstrumentation();
         metrics.AddConsoleExporter();
     });
@@ -187,6 +189,8 @@ builder.Services.AddAuthorizationBuilder()
 
             return CryptographicOperations.FixedTimeEquals(apiKeySpan, expectedKeySpan);
         }));
+
+builder.Services.AddSingleton<TournamentMetrics>();
 
 builder.Services
     .AddHttpContextAccessor()

--- a/TournamentAPI/Program.cs
+++ b/TournamentAPI/Program.cs
@@ -191,6 +191,7 @@ builder.Services.AddAuthorizationBuilder()
         }));
 
 builder.Services.AddSingleton<TournamentMetrics>();
+builder.Services.AddHostedService(sp => sp.GetRequiredService<TournamentMetrics>());
 
 builder.Services
     .AddHttpContextAccessor()

--- a/TournamentAPI/Tournaments/TournamentMutations.cs
+++ b/TournamentAPI/Tournaments/TournamentMutations.cs
@@ -5,6 +5,7 @@ using System.Security.Claims;
 using TournamentAPI.Data;
 using TournamentAPI.Data.Models;
 using TournamentAPI.Extensions;
+using TournamentAPI.Metrics;
 
 namespace TournamentAPI.Tournaments;
 
@@ -62,6 +63,7 @@ public class TournamentMutations
         ClaimsPrincipal userClaims,
         ApplicationDbContext context,
         IResolverContext resolverContext,
+        TournamentMetrics tournamentMetrics,
         CancellationToken token)
     {
         var userId = userClaims.GetUserId();
@@ -79,6 +81,8 @@ public class TournamentMutations
 
         context.Tournaments.Add(tournament);
         await context.SaveChangesAsync(token);
+
+        tournamentMetrics.IncrementTournamentsCreated();
 
         return context.Tournaments.Where(t => t.Id == tournament.Id);
     }


### PR DESCRIPTION
#### Summary
This PR introduces OpenTelemetry-based metrics to monitor tournament creation and the number of active tournaments in the TournamentAPI. It registers a new metrics service and integrates it into the tournament creation workflow.

#### Changes
- TournamentMetrics.cs: Implements a hosted service to track tournaments created (counter) and active tournaments (observable gauge).
- MetricConstants.cs: Defines metric name constants for consistency.
- Program.cs: Registers the TournamentMetrics service and configures OpenTelemetry to use the new meter.
- TournamentMutations.cs: Injects TournamentMetrics and increments the tournaments created counter upon tournament creation.
