### PR TITLE
feat: integrate grafana and prometheus

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,6 +17,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="9.0.11" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 - [General Info](#general-info)
 - [Technologies](#technologies)
+- [Running the API](#running-the-api)
 - [Detailed API Documentation](#detailed-api-documentation)
   - [Authentication](#authentication)
   - [Tournament Management](#tournament-management)
@@ -35,6 +36,46 @@
 - **NBomber** (for load testing)
 
 ---
+
+
+## Running the API
+
+### Prerequisites
+
+- [.NET 9 SDK](https://dotnet.microsoft.com/download/dotnet/9.0)
+- [Docker](https://www.docker.com/) (for Prometheus and Grafana)
+
+### Start Prometheus and Grafana
+
+The API exports metrics via OpenTelemetry's OTLP exporter directly to Prometheus. Before starting the API, bring up the observability stack with Docker Compose:
+
+```bash
+docker-compose up -d
+```
+
+This starts:
+
+| Service | URL |
+| --- | --- |
+| Prometheus | http://localhost:5431 |
+| Grafana | http://localhost:3000 |
+
+Prometheus is configured with `--web.enable-otlp-receiver` so it accepts OTLP pushes from the API. The scrape interval is set to 15 s globally (10 s for the Prometheus self-scrape job).
+
+### Start the API
+
+```bash
+dotnet run --project TournamentAPI
+```
+
+The API will push metrics to Prometheus automatically once running.
+
+### Grafana
+
+Open `http://localhost:3000`, log in with the default credentials (`admin` / `admin`), and add Prometheus (`http://prometheus:9090`) as a data source to build dashboards from the collected metrics.
+
+---
+
 
 ## Detailed API Documentation
 

--- a/TournamentAPI.Benchmarks/packages.lock.json
+++ b/TournamentAPI.Benchmarks/packages.lock.json
@@ -1356,6 +1356,7 @@
           "Microsoft.EntityFrameworkCore.SqlServer": "[9.0.11, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[9.0.11, )",
           "OpenTelemetry.Exporter.Console": "[1.15.3, )",
+          "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
@@ -1507,6 +1508,15 @@
         "requested": "[1.15.3, )",
         "resolved": "1.15.3",
         "contentHash": "QBGOoPwLHDXX+hXeUpspOjsqEn4vMkLw672QN+MzVWFBzjf625DdxLxhzowS1J/dRtW93U34rRbJec+4808fkg==",
+        "dependencies": {
+          "OpenTelemetry": "1.15.3"
+        }
+      },
+      "OpenTelemetry.Exporter.OpenTelemetryProtocol": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.3, )",
+        "resolved": "1.15.3",
+        "contentHash": "FEXJepcseTGbATiCkUfP7ipoFEYYfl/0UmmUwi0KxCPg9PaUA8ab2P1LGopK+/HExasJ1ZutFhZrN6WvUIR23g==",
         "dependencies": {
           "OpenTelemetry": "1.15.3"
         }

--- a/TournamentAPI.IntegrationTests/packages.lock.json
+++ b/TournamentAPI.IntegrationTests/packages.lock.json
@@ -1372,6 +1372,7 @@
           "Microsoft.EntityFrameworkCore.SqlServer": "[9.0.11, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[9.0.11, )",
           "OpenTelemetry.Exporter.Console": "[1.15.3, )",
+          "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
@@ -1523,6 +1524,15 @@
         "requested": "[1.15.3, )",
         "resolved": "1.15.3",
         "contentHash": "QBGOoPwLHDXX+hXeUpspOjsqEn4vMkLw672QN+MzVWFBzjf625DdxLxhzowS1J/dRtW93U34rRbJec+4808fkg==",
+        "dependencies": {
+          "OpenTelemetry": "1.15.3"
+        }
+      },
+      "OpenTelemetry.Exporter.OpenTelemetryProtocol": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.3, )",
+        "resolved": "1.15.3",
+        "contentHash": "FEXJepcseTGbATiCkUfP7ipoFEYYfl/0UmmUwi0KxCPg9PaUA8ab2P1LGopK+/HExasJ1ZutFhZrN6WvUIR23g==",
         "dependencies": {
           "OpenTelemetry": "1.15.3"
         }

--- a/TournamentAPI.LoadTests/packages.lock.json
+++ b/TournamentAPI.LoadTests/packages.lock.json
@@ -2499,6 +2499,7 @@
           "Microsoft.EntityFrameworkCore.SqlServer": "[9.0.11, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[9.0.11, )",
           "OpenTelemetry.Exporter.Console": "[1.15.3, )",
+          "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
@@ -2650,6 +2651,15 @@
         "requested": "[1.15.3, )",
         "resolved": "1.15.3",
         "contentHash": "QBGOoPwLHDXX+hXeUpspOjsqEn4vMkLw672QN+MzVWFBzjf625DdxLxhzowS1J/dRtW93U34rRbJec+4808fkg==",
+        "dependencies": {
+          "OpenTelemetry": "1.15.3"
+        }
+      },
+      "OpenTelemetry.Exporter.OpenTelemetryProtocol": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.3, )",
+        "resolved": "1.15.3",
+        "contentHash": "FEXJepcseTGbATiCkUfP7ipoFEYYfl/0UmmUwi0KxCPg9PaUA8ab2P1LGopK+/HExasJ1ZutFhZrN6WvUIR23g==",
         "dependencies": {
           "OpenTelemetry": "1.15.3"
         }

--- a/TournamentAPI.UnitTests/packages.lock.json
+++ b/TournamentAPI.UnitTests/packages.lock.json
@@ -1143,6 +1143,7 @@
           "Microsoft.EntityFrameworkCore.SqlServer": "[9.0.11, )",
           "Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore": "[9.0.11, )",
           "OpenTelemetry.Exporter.Console": "[1.15.3, )",
+          "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.15.3, )",
           "OpenTelemetry.Extensions.Hosting": "[1.15.3, )",
           "OpenTelemetry.Instrumentation.AspNetCore": "[1.15.2, )",
           "OpenTelemetry.Instrumentation.Http": "[1.15.1, )",
@@ -1291,6 +1292,15 @@
         "requested": "[1.15.3, )",
         "resolved": "1.15.3",
         "contentHash": "QBGOoPwLHDXX+hXeUpspOjsqEn4vMkLw672QN+MzVWFBzjf625DdxLxhzowS1J/dRtW93U34rRbJec+4808fkg==",
+        "dependencies": {
+          "OpenTelemetry": "1.15.3"
+        }
+      },
+      "OpenTelemetry.Exporter.OpenTelemetryProtocol": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.3, )",
+        "resolved": "1.15.3",
+        "contentHash": "FEXJepcseTGbATiCkUfP7ipoFEYYfl/0UmmUwi0KxCPg9PaUA8ab2P1LGopK+/HExasJ1ZutFhZrN6WvUIR23g==",
         "dependencies": {
           "OpenTelemetry": "1.15.3"
         }

--- a/TournamentAPI/Configuration/Extensions/MetricsExtensions.cs
+++ b/TournamentAPI/Configuration/Extensions/MetricsExtensions.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
 using TournamentAPI.Metrics;
 
 namespace TournamentAPI.Configuration.Extensions;
@@ -8,7 +7,6 @@ internal static class MetricsExtensions
     internal static IServiceCollection AddApplicationMetrics(this IServiceCollection services)
     {
         services.AddSingleton<TournamentMetrics>();
-        services.AddHostedService(sp => sp.GetRequiredService<TournamentMetrics>());
 
         return services;
     }

--- a/TournamentAPI/Configuration/Extensions/TelemetryExtensions.cs
+++ b/TournamentAPI/Configuration/Extensions/TelemetryExtensions.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
 using OpenTelemetry.Metrics;
 using OpenTelemetry.Resources;
 using OpenTelemetry.Trace;
@@ -23,7 +22,11 @@ internal static class TelemetryExtensions
             {
                 metrics.AddMeter(MetricConstants.TournamentMeterName);
                 metrics.AddAspNetCoreInstrumentation();
-                metrics.AddConsoleExporter();
+                metrics.AddOtlpExporter(o =>
+                {
+                    o.Endpoint = new Uri("http://localhost:5431/api/v1/otlp/v1/metrics");
+                    o.Protocol = OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf;
+                });
             });
 
         return services;

--- a/TournamentAPI/Metrics/TournamentMetrics.cs
+++ b/TournamentAPI/Metrics/TournamentMetrics.cs
@@ -1,40 +1,22 @@
 using System.Diagnostics.Metrics;
-using TournamentAPI.Data;
-using TournamentAPI.Data.Models;
 
 namespace TournamentAPI.Metrics;
 
-public class TournamentMetrics : IHostedService
+public class TournamentMetrics
 {
-    private readonly IServiceScopeFactory _serviceScopeFactory;
     private readonly Counter<int> _tournamentsCreated;
+    private readonly UpDownCounter<int> _activeTournaments;
 
-    public TournamentMetrics(IMeterFactory meterFactory, IServiceScopeFactory serviceScopeFactory)
+    public TournamentMetrics(IMeterFactory meterFactory)
     {
-        _serviceScopeFactory = serviceScopeFactory;
-
         var meter = meterFactory.Create(MetricConstants.TournamentMeterName);
         _tournamentsCreated = meter.CreateCounter<int>("tournamentapi.tournaments.tournaments_created", description: "Number of tournaments created");
-
-        _ = meter.CreateObservableGauge(
-            "tournamentapi.tournaments.active_tournaments",
-            () => GetActiveTournamentsCount(),
-            description: "Number of currently active tournaments");
+        _activeTournaments = meter.CreateUpDownCounter<int>("tournamentapi.tournaments.active_tournaments", description: "Number of currently active tournaments");
     }
 
-    public void IncrementTournamentsCreated()
-    {
-        _tournamentsCreated.Add(1);
-    }
+    public void IncrementTournamentsCreated() => _tournamentsCreated.Add(1);
 
-    private int GetActiveTournamentsCount()
-    {
-        using var scope = _serviceScopeFactory.CreateScope();
-        var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-        return context.Tournaments.Count(t => t.Status == TournamentStatus.Open);
-    }
+    public void TournamentOpened() => _activeTournaments.Add(1);
 
-    public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
-
-    public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+    public void TournamentClosed() => _activeTournaments.Add(-1);
 }

--- a/TournamentAPI/TournamentAPI.csproj
+++ b/TournamentAPI/TournamentAPI.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net9.0</TargetFramework>
@@ -24,6 +24,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" />
     <PackageReference Include="OpenTelemetry.Exporter.Console" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" />
     <PackageReference Include="OpenTelemetry.Extensions.Hosting" />
     <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" />

--- a/TournamentAPI/Tournaments/TournamentMutations.cs
+++ b/TournamentAPI/Tournaments/TournamentMutations.cs
@@ -83,6 +83,8 @@ public class TournamentMutations
         await context.SaveChangesAsync(token);
 
         tournamentMetrics.IncrementTournamentsCreated();
+        if (tournament.Status == TournamentStatus.Open)
+            tournamentMetrics.TournamentOpened();
 
         return context.Tournaments.Where(t => t.Id == tournament.Id);
     }
@@ -95,6 +97,7 @@ public class TournamentMutations
         ClaimsPrincipal userClaims,
         ApplicationDbContext context,
         IResolverContext resolverContext,
+        TournamentMetrics tournamentMetrics,
         CancellationToken token)
     {
         var userId = userClaims.GetUserId();
@@ -112,12 +115,19 @@ public class TournamentMutations
             return null;
         tournament.Name = input.Name;
 
-
         if (input.StartDate != null)
             tournament.StartDate = input.StartDate.Value;
 
         if (input.Status != null)
+        {
+            var previousStatus = tournament.Status;
             tournament.Status = input.Status.Value;
+
+            if (previousStatus != TournamentStatus.Open && tournament.Status == TournamentStatus.Open)
+                tournamentMetrics.TournamentOpened();
+            else if (previousStatus == TournamentStatus.Open && tournament.Status != TournamentStatus.Open)
+                tournamentMetrics.TournamentClosed();
+        }
 
         await context.SaveChangesAsync(token);
 
@@ -130,6 +140,7 @@ public class TournamentMutations
         ClaimsPrincipal userClaims,
         ApplicationDbContext context,
         IResolverContext resolverContext,
+        TournamentMetrics tournamentMetrics,
         CancellationToken token)
     {
         var userId = userClaims.GetUserId();
@@ -145,6 +156,8 @@ public class TournamentMutations
 
         if (resolverContext.TryReportError(TournamentValidations.ValidateIsOwner(tournament!.OwnerId, userId, tournamentId)))
             return null;
+
+        var wasOpen = tournament!.Status == TournamentStatus.Open;
 
         tournament.IsDeleted = true;
 
@@ -163,6 +176,10 @@ public class TournamentMutations
         }
 
         await context.SaveChangesAsync(token);
+
+        if (wasOpen)
+            tournamentMetrics.TournamentClosed();
+
         return true;
     }
 }

--- a/TournamentAPI/packages.lock.json
+++ b/TournamentAPI/packages.lock.json
@@ -168,6 +168,15 @@
           "OpenTelemetry": "1.15.3"
         }
       },
+      "OpenTelemetry.Exporter.OpenTelemetryProtocol": {
+        "type": "Direct",
+        "requested": "[1.15.3, )",
+        "resolved": "1.15.3",
+        "contentHash": "FEXJepcseTGbATiCkUfP7ipoFEYYfl/0UmmUwi0KxCPg9PaUA8ab2P1LGopK+/HExasJ1ZutFhZrN6WvUIR23g==",
+        "dependencies": {
+          "OpenTelemetry": "1.15.3"
+        }
+      },
       "OpenTelemetry.Extensions.Hosting": {
         "type": "Direct",
         "requested": "[1.15.3, )",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+      - '--web.enable-otlp-receiver'
+    ports:
+      - 5431:9090
+    volumes:
+      - ./prometheus/:/etc/prometheus/
+      - prometheus:/prometheus
+  
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - 3000:3000
+    volumes:
+      - grafana:/var/lib/grafana
+
+volumes:
+  prometheus:
+  grafana:

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    scheme: 'http'
+    scrape_interval: 10s
+    scrape_timeout: 5s
+    static_configs:
+      - targets: ['localhost:9090']


### PR DESCRIPTION
#### Summary
Implements OTLP metrics export to Prometheus and visualization with Grafana, refactors tournament metrics tracking, and provides local observability setup and documentation.

#### Changes
- TelemetryExtensions.cs: Switched from console to OTLP exporter for metrics, targeting Prometheus.
- TournamentMetrics.cs and TournamentMutations.cs: Refactored metrics logic to use UpDownCounter and explicit open/close tracking methods, removing DB dependency.
- docker-compose.yml and prometheus.yml: Added configuration for local Prometheus (with OTLP receiver) and Grafana.
- README.md: Added instructions for running the API with Prometheus and Grafana for metrics visualization.
