### PR TITLE
ci: add update-locks job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,35 @@ env:
   SOLUTION_PATH: 'TournamentAPI.sln'
 
 jobs:
+  update-locks:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 9.0.x
+
+      - name: Regenerate lock files
+        run: dotnet restore ${{ env.SOLUTION_PATH }}
+
+      - name: Git
+        run: |
+          git diff --quiet "**/packages.lock.json" && echo "Nothing to commit" && exit 0
+          git config user.name "github-actions[bot]"
+          git config user.email "<>"
+          git add "**/packages.lock.json"
+          git commit -m "chore: regenerate packages.lock.json"
+          git push
+
   build-test:
+    needs: update-lock-files
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
   SOLUTION_PATH: 'TournamentAPI.sln'
 
 jobs:
-  update-locks:
+  update-lock-files:
     if: github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
#### Summary
This PR adds a new GitHub Actions job to automatically regenerate `.NET` lock files when triggered by Dependabot and ensures the build process depends on updated lock files.

#### Changes
- **ci.yml**: Added a new `update-locks` job to regenerate `packages.lock.json` files, commit changes, and push them to the repository.
- **ci.yml**: Updated the `build-test` job to depend on the `update-locks` job for ensuring lock files are up-to-date.
